### PR TITLE
[#57] Builder 어노테이션 제거 및 Builder 패턴 직접 구현 In MEMBER

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/configuration/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/chainsmoker/marronnier/configuration/auth/CustomOAuth2UserService.java
@@ -59,9 +59,11 @@ public class CustomOAuth2UserService  extends DefaultOAuth2UserService {
                             .name(attributes.getName())
                             .UID(attributes.getUid())
                             .build());
-            sessionUser = SessionUser.builder().id(newMember.getId()).name(newMember.getName()).build();
+            //sessionUser = SessionUser.builder().addId(newMember.getId()).name(newMember.getName()).build();
+            sessionUser = SessionUser.builder(newMember.getId(), newMember.getName()).build();
         } else {
-            sessionUser = SessionUser.builder().id(member.getId()).name(member.getName()).build();
+            //sessionUser = SessionUser.builder().id(member.getId()).name(member.getName()).build();
+            sessionUser = SessionUser.builder(member.getId(), member.getName()).build();
         }
         return sessionUser;
     }

--- a/src/main/java/com/chainsmoker/marronnier/configuration/auth/SessionUser.java
+++ b/src/main/java/com/chainsmoker/marronnier/configuration/auth/SessionUser.java
@@ -1,13 +1,47 @@
 package com.chainsmoker.marronnier.configuration.auth;
 
-import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.Member;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@Builder
 public class SessionUser {
-    private Long id;
-    private String name;
+    private final long id;
+    private final String name;
+
+    private SessionUser(Builder builder) {
+        this.id = builder.id;
+        this.name = builder.name;
+    }
+
+    public static Builder builder(long id, String name) {
+        return new Builder(id, name);
+    }
+
+    public static class Builder {
+        private final long id;
+        private final String name;
+
+        private Builder(long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        /**
+         * 위 생성자에서 만약 입력 값 중 옵셔널 값일 경우 Setter를 통해 값을 초기화
+         * 위 경우 Builder 클래스의 옵셔널 필드는 final 키워드 사용 불가
+         * 이러한 경우 Builder 패턴을 사용하는 의미가 크게 낮아짐.
+         */
+
+        public SessionUser build() {
+            return new SessionUser(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SessionUser{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
 }
+

--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/service/RegistMemberService.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/service/RegistMemberService.java
@@ -18,11 +18,16 @@ public class RegistMemberService {
     }
 
     public Member create(CreateMemberDTO memberDTO) {
-        Member memberEntity = Member.builder()
-                .UID(memberDTO.getUID())
-                .name(memberDTO.getName())
-                .platform(PlatformEnum.KAKAO)
-                .build();
+//        Member memberEntity = Member.builder()
+//                .UID(memberDTO.getUID())
+//                .name(memberDTO.getName())
+//                .platform(PlatformEnum.KAKAO)
+//                .build();
+        Member memberEntity = new Member(
+                memberDTO.getName(),
+                memberDTO.getUID(),
+                PlatformEnum.KAKAO
+        );
         return memberRepository.save(memberEntity);
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/entity/Member.java
@@ -5,14 +5,10 @@ import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumTyp
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumType.PlatformEnum;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
-import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
 
@@ -44,13 +40,34 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private PlatformEnum platform;
 
-    @Builder
-    public Member(String name, Long UID, String address, GenderEnum gender, LocalDate birthDate, PlatformEnum platform) {
+    public Member(String name, Long uid, String address, GenderEnum gender, LocalDate birthDate, PlatformEnum platform) {
         this.name = name;
-        this.UID = UID;
+        this.UID = uid;
         this.address = address;
         this.gender = gender;
         this.birthDate = birthDate;
         this.platform = platform;
+    }
+
+    public Member(String name, long uid, PlatformEnum platform) {
+        this.name = name;
+        this.UID = uid;
+        this.platform = platform;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public void setGender(GenderEnum gender) {
+        this.gender = gender;
+    }
+
+    public void setBirthDate(LocalDate birthDate) {
+        this.birthDate = birthDate;
     }
 }


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #57 
---
# 어떤 위험이나 장애가 발견되었는지

---
* Builder 어노테이션의 단점 이해
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* Member 엔티티 생성자로 생성
* Builder 어노테이션 제거
* Builder 패턴 직접 구현
```java
package com.chainsmoker.marronnier.configuration.auth;

import lombok.Getter;

@Getter
public class SessionUser {
    private final long id;
    private final String name;

    private SessionUser(Builder builder) {
        this.id = builder.id;
        this.name = builder.name;
    }

    public static Builder builder(long id, String name) {
        return new Builder(id, name);
    }

    public static class Builder {
        private final long id;
        private final String name;

        private Builder(long id, String name) {
            this.id = id;
            this.name = name;
        }

        /**
         * 위 생성자에서 만약 입력 값 중 옵셔널 값일 경우 Setter를 통해 값을 초기화
         * 위 경우 Builder 클래스의 옵셔널 필드는 final 키워드 사용 불가
         * 이러한 경우 Builder 패턴을 사용하는 의미가 크게 낮아짐.
         */

        public SessionUser build() {
            return new SessionUser(this);
        }
    }

    @Override
    public String toString() {
        return "SessionUser{" +
                "id=" + id +
                ", name='" + name + '\'' +
                '}';
    }
}

``` 
추후 위 코드를 통해 Builder 어노테이션의 단점을 설명하겠습니다.

---

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 없음
