### PR TITLE
[Closes #73] 어드민 권한을 통한 로그인 인증 구현

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
@@ -1,0 +1,41 @@
+package com.chainsmoker.marronnier.admin.command.application.controller;
+
+import com.chainsmoker.marronnier.admin.command.application.dto.CreateAdminDTO;
+import com.chainsmoker.marronnier.admin.command.application.service.RegistAdminService;
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.vo.PasswordVO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpSession;
+
+@Controller
+@RequestMapping("/admin")
+public class CreateAdminController {
+
+    private final RegistAdminService registAdminService;
+
+    @Autowired
+    public CreateAdminController(RegistAdminService registAdminService) {
+        this.registAdminService = registAdminService;
+    }
+
+    @GetMapping("regist")
+    public String registAdminView() {
+        return "admin/regist";
+    }
+
+    @PostMapping("regist")
+    public String registAdmin( @ModelAttribute("name") String adminName, @ModelAttribute("loginId") String loginId, @ModelAttribute("password") String password) {
+        // @ModelAttribute("adminName") String adminName, @ModelAttribute("loginId") String loginId, @ModelAttribute("password") String password
+        CreateAdminDTO createAdminDTO = new CreateAdminDTO(loginId, password, adminName);
+        System.out.println(createAdminDTO.toString());
+        long addResult = registAdminService.create(createAdminDTO);
+        if (addResult > 0) {
+            return "redirect:/admin/login";
+        } else {
+            return "redirect:/admin/regist";
+        }
+    }
+
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
@@ -2,12 +2,9 @@ package com.chainsmoker.marronnier.admin.command.application.controller;
 
 import com.chainsmoker.marronnier.admin.command.application.dto.CreateAdminDTO;
 import com.chainsmoker.marronnier.admin.command.application.service.RegistAdminService;
-import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.vo.PasswordVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.HttpSession;
 
 @Controller
 @RequestMapping("/admin")
@@ -26,10 +23,8 @@ public class CreateAdminController {
     }
 
     @PostMapping("regist")
-    public String registAdmin( @ModelAttribute("name") String adminName, @ModelAttribute("loginId") String loginId, @ModelAttribute("password") String password) {
+    public String registAdmin(CreateAdminDTO createAdminDTO) {
         // @ModelAttribute("adminName") String adminName, @ModelAttribute("loginId") String loginId, @ModelAttribute("password") String password
-        CreateAdminDTO createAdminDTO = new CreateAdminDTO(loginId, password, adminName);
-        System.out.println(createAdminDTO.toString());
         long addResult = registAdminService.create(createAdminDTO);
         if (addResult > 0) {
             return "redirect:/admin/login";

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/LoginAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/LoginAdminController.java
@@ -1,0 +1,35 @@
+package com.chainsmoker.marronnier.admin.command.application.controller;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Controller
+@RequestMapping("/admin")
+public class LoginAdminController {
+    public LoginAdminController() {}
+
+    @GetMapping("login")
+    public String registAdminView() {
+        return "admin/login";
+    }
+
+    @GetMapping("/logout")
+    public String logout(HttpServletRequest request, HttpServletResponse response) {
+
+        Authentication authentication =
+                SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null) {
+            new SecurityContextLogoutHandler().logout(request, response, authentication);
+        }
+
+        return "redirect:/login";
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/MainAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/MainAdminController.java
@@ -1,4 +1,38 @@
 package com.chainsmoker.marronnier.admin.command.application.controller;
 
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.AdminDetail;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Controller
+@RequestMapping("/admin")
 public class MainAdminController {
+    public MainAdminController() {}
+
+    @GetMapping("home")
+    public String AdminMainView(Authentication authentication, Model model) {
+
+        if(authentication.isAuthenticated()) {
+            AdminDetail admin = (AdminDetail) authentication.getPrincipal();
+
+            model.addAttribute("adminName", admin.getUsername());
+            return "admin/home";
+        } else {
+            return "admin/login";
+        }
+    }
+
+    @PostMapping("error")
+    public String AdminErrorView(HttpServletRequest request, HttpServletResponse response, Model model) {
+            String errorMessage = (String) request.getAttribute("errorMessage");
+            model.addAttribute("errorMessage", errorMessage);
+        return "admin/error";
+    }
 }

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/MainAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/MainAdminController.java
@@ -1,0 +1,4 @@
+package com.chainsmoker.marronnier.admin.command.application.controller;
+
+public class MainAdminController {
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/dto/AdminDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/dto/AdminDTO.java
@@ -1,0 +1,40 @@
+package com.chainsmoker.marronnier.admin.command.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminDTO {
+    private String loginId;
+    private String name;
+
+    public AdminDTO(String loginId, String name) {
+        this.loginId = loginId;
+        this.name = name;
+    }
+
+    public String getLoginId() {
+        return loginId;
+    }
+
+    public void setLoginId(String loginId) {
+        this.loginId = loginId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AdminDTO{" +
+                "loginId='" + loginId + '\'' +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/dto/CreateAdminDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/dto/CreateAdminDTO.java
@@ -1,6 +1,5 @@
 package com.chainsmoker.marronnier.admin.command.application.dto;
 
-import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.vo.PasswordVO;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,12 +7,12 @@ import lombok.Setter;
 @Setter
 public class CreateAdminDTO {
     private String loginId;
-    private PasswordVO password;
+    private String password;
     private String name;
 
     public CreateAdminDTO(String loginId, String password, String name) {
         this.loginId = loginId;
-        this.password = new PasswordVO(password);
+        this.password = password;
         this.name = name;
     }
 

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/dto/CreateAdminDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/dto/CreateAdminDTO.java
@@ -1,0 +1,28 @@
+package com.chainsmoker.marronnier.admin.command.application.dto;
+
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.vo.PasswordVO;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateAdminDTO {
+    private String loginId;
+    private PasswordVO password;
+    private String name;
+
+    public CreateAdminDTO(String loginId, String password, String name) {
+        this.loginId = loginId;
+        this.password = new PasswordVO(password);
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "CreateAdminDTO{" +
+                "loginId=" + loginId +
+                ", password=" + password +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/service/CustomUserDetailsService.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/service/CustomUserDetailsService.java
@@ -1,0 +1,39 @@
+package com.chainsmoker.marronnier.admin.command.application.service;
+
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.Admin;
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.AdminDetail;
+import com.chainsmoker.marronnier.admin.command.domain.repository.AdminRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final AdminRepository adminRepository;
+    @Autowired
+    public CustomUserDetailsService(AdminRepository adminRepository) {
+        this.adminRepository = adminRepository;
+    }
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Admin admin = adminRepository.findAdminByLoginId(username);
+//        AdminDetail adminDetail = new AdminDetail(admin);
+//        List<SimpleGrantedAuthority> grantedAuthorities = adminDetail.getAuthorities().stream().map(authority -> {
+//            return new SimpleGrantedAuthority(admin.getRole().getKey());
+//        }).collect(Collectors.toList());
+//        return new User(admin.getName(), admin.getPassword(), grantedAuthorities);
+        return  new AdminDetail(
+                admin.getId(),
+                admin.getLoginId(),
+                admin.getName(),
+                admin.getPassword(),
+                admin.getRole()
+        );
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/service/RegistAdminService.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/service/RegistAdminService.java
@@ -2,26 +2,29 @@ package com.chainsmoker.marronnier.admin.command.application.service;
 
 import com.chainsmoker.marronnier.admin.command.application.dto.CreateAdminDTO;
 import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.Admin;
-import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.EnumType.Role;
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.EnumType.AdminRole;
 import com.chainsmoker.marronnier.admin.command.domain.repository.AdminRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RegistAdminService {
 
     private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public RegistAdminService(AdminRepository adminRepository) {
+    public RegistAdminService(AdminRepository adminRepository, PasswordEncoder passwordEncoder) {
         this.adminRepository = adminRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public long create(CreateAdminDTO createAdminDTO) {
         Admin adminEntity = new Admin(
                 createAdminDTO.getName(),
-                Role.ADMIN,
-                createAdminDTO.getPassword(),
+                AdminRole.ADMIN,
+                passwordEncoder.encode(createAdminDTO.getPassword()),
                 createAdminDTO.getLoginId()
         );
 

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/service/RegistAdminService.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/service/RegistAdminService.java
@@ -1,0 +1,31 @@
+package com.chainsmoker.marronnier.admin.command.application.service;
+
+import com.chainsmoker.marronnier.admin.command.application.dto.CreateAdminDTO;
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.Admin;
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.EnumType.Role;
+import com.chainsmoker.marronnier.admin.command.domain.repository.AdminRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RegistAdminService {
+
+    private final AdminRepository adminRepository;
+
+    @Autowired
+    public RegistAdminService(AdminRepository adminRepository) {
+        this.adminRepository = adminRepository;
+    }
+
+    public long create(CreateAdminDTO createAdminDTO) {
+        Admin adminEntity = new Admin(
+                createAdminDTO.getName(),
+                Role.ADMIN,
+                createAdminDTO.getPassword(),
+                createAdminDTO.getLoginId()
+        );
+
+        Admin admin = adminRepository.save(adminEntity);
+        return admin.getId();
+    };
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/Admin.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/Admin.java
@@ -1,7 +1,6 @@
 package com.chainsmoker.marronnier.admin.command.domain.aggragate.entity;
 
-import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.vo.PasswordVO;
-import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.EnumType.Role;
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.EnumType.AdminRole;
 import lombok.Getter;
 
 import javax.persistence.*;
@@ -19,20 +18,31 @@ public class Admin {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role;
+    private AdminRole role;
 
-    @Embedded
-    private PasswordVO password;
+    @Column(nullable = false)
+    private String password;
 
     @Column(name = "login_id")
     private String loginId;
 
-    public Admin() {};
+    public Admin() {}
 
-    public Admin(String name, Role role, PasswordVO password, String loginId) {
+    public Admin(String name, AdminRole role, String password, String loginId) {
         this.name = name;
         this.role = role;
         this.password = password;
         this.loginId = loginId;
+    }
+
+    @Override
+    public String toString() {
+        return "Admin{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", role=" + role +
+                ", password=" + password +
+                ", loginId='" + loginId + '\'' +
+                '}';
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/Admin.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/Admin.java
@@ -1,0 +1,38 @@
+package com.chainsmoker.marronnier.admin.command.domain.aggragate.entity;
+
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.vo.PasswordVO;
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.EnumType.Role;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name="ADMIN_TB")
+@Getter
+public class Admin {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 30)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Embedded
+    private PasswordVO password;
+
+    @Column(name = "login_id")
+    private String loginId;
+
+    public Admin() {};
+
+    public Admin(String name, Role role, PasswordVO password, String loginId) {
+        this.name = name;
+        this.role = role;
+        this.password = password;
+        this.loginId = loginId;
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/AdminDetail.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/AdminDetail.java
@@ -1,0 +1,75 @@
+package com.chainsmoker.marronnier.admin.command.domain.aggragate.entity;
+
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.EnumType.AdminRole;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class AdminDetail implements UserDetails {
+    private final Long id;
+    private final String loginId;
+    private final String name;
+    private final String password;
+    private final AdminRole role;
+
+    public AdminDetail(Long id, String loginId, String name, String password, AdminRole role) {
+        this.id = id;
+        this.loginId = loginId;
+        this.name = name;
+        this.password = password;
+        this.role = role;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        ArrayList<GrantedAuthority> auth = new ArrayList<>();
+        auth.add(new SimpleGrantedAuthority(role.getKey()));
+        return auth;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return name;
+    }
+
+    public long getUserId() {return id; }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "AdminDetail{" +
+                "id=" + id +
+                ", loginId='" + loginId + '\'' +
+                ", name='" + name + '\'' +
+                ", password='" + password + '\'' +
+                ", role=" + role +
+                '}';
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/EnumType/AdminRole.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/EnumType/AdminRole.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum Role {
+public enum AdminRole {
 
     ADMIN("ROLE_ADMIN", "관리자");
 

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/EnumType/Role.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/EnumType/Role.java
@@ -1,0 +1,14 @@
+package com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.EnumType;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/vo/PasswordVO.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/vo/PasswordVO.java
@@ -1,0 +1,38 @@
+package com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.vo;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+@Embeddable
+public class PasswordVO {
+    @Column(nullable = false, name = "password")
+    private String value;
+
+    public PasswordVO(String value) {
+
+        MessageDigest md = null;
+        try {
+            md = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        md.update((value).getBytes());
+        byte[] pwdSalt = md.digest();
+
+        StringBuffer pwdSb = new StringBuffer();
+        for(byte b : pwdSalt) {
+            pwdSb.append(String.format("%02x", b));
+        }
+        this.value = pwdSb.toString();
+    }
+
+    protected PasswordVO() {}
+
+    public String getValue() {
+        return this.value;
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/domain/repository/AdminRepository.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/domain/repository/AdminRepository.java
@@ -1,0 +1,7 @@
+package com.chainsmoker.marronnier.admin.command.domain.repository;
+
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+}

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/domain/repository/AdminRepository.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/domain/repository/AdminRepository.java
@@ -2,6 +2,9 @@ package com.chainsmoker.marronnier.admin.command.domain.repository;
 
 import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface AdminRepository extends JpaRepository<Admin, Long> {
+    Admin findAdminByLoginId(String loginId);
 }

--- a/src/main/java/com/chainsmoker/marronnier/common/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/chainsmoker/marronnier/common/handler/OAuth2SuccessHandler.java
@@ -4,18 +4,14 @@ import com.chainsmoker.marronnier.configuration.auth.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/com/chainsmoker/marronnier/configuration/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/chainsmoker/marronnier/configuration/auth/CustomOAuth2UserService.java
@@ -23,9 +23,9 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
-@Service
 @Transactional
 @RequiredArgsConstructor
+@Service
 public class CustomOAuth2UserService  extends DefaultOAuth2UserService {
     private final RegistMemberService registMemberService;
     private final FindMemberService findMemberService;

--- a/src/main/java/com/chainsmoker/marronnier/configuration/auth/SecurityConfiguration.java
+++ b/src/main/java/com/chainsmoker/marronnier/configuration/auth/SecurityConfiguration.java
@@ -1,13 +1,17 @@
 package com.chainsmoker.marronnier.configuration.auth;
 
+import com.chainsmoker.marronnier.admin.command.domain.aggragate.entity.EnumType.AdminRole;
 import com.chainsmoker.marronnier.common.handler.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumType.Role;
+
+import java.io.IOException;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -15,26 +19,72 @@ import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumTyp
 public class SecurityConfiguration {
 
     private final CustomOAuth2UserService customOAuth2UserService;
-    private final OAuth2SuccessHandler successHandler;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf().disable();
         http.authorizeRequests()
                 .antMatchers("/","/auth/**", "/css/**", "/images/**",
-                "/js/**", "/h2-console/**","/login/**", "/admin/regist", "/admin/login").permitAll()
-                .antMatchers("/basket/**", "/profile/**", "/find/**", "/feed/**").hasRole(Role.MEMBER.name())
+                "/js/**", "/h2-console/**","/login/**", "/admin/regist", "/admin/login", "/feed/feed","/admin/error").permitAll()
+                .antMatchers("/home","basket/**", "/profile/**", "/find/**", "/feed/**", "/apply/self").hasRole(Role.MEMBER.name())
+                .antMatchers("/apply/**", "/report/**", "/admin/**").hasRole(AdminRole.ADMIN.name())
                 .anyRequest().authenticated()
 //			    .antMatchers("/**").authenticated() // 인가된 사용자만 접근 가능하도록 설정
 //			    .antMatchers("게시물등").hasRole(Role.USER.name()) // 특정 ROLE을 가진 사용자만 접근 가능하도록 설정
                 .and()
-                .logout()
-                .logoutSuccessUrl("/")
-                .and()
                 .oauth2Login()
-                .successHandler(successHandler)
-                .userInfoEndpoint()
-                .userService(customOAuth2UserService);
+                    .authorizationEndpoint()
+                        .and()
+                        .userInfoEndpoint()
+                            .userService(customOAuth2UserService)
+                .and()
+                .successHandler(oAuth2SuccessHandler)
+                ;
 
+        http.formLogin()
+                .loginPage("/admin/login")
+                .loginProcessingUrl("/admin/login")
+                .usernameParameter("loginId")
+                .passwordParameter("password")
+                .successHandler((request, response, authentication) -> {
+                    System.out.println("authentication : " + authentication.getName());
+                    try {
+                        response.sendRedirect("/admin/home");
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .failureHandler((request, response, exception) -> {
+                    request.setAttribute("errorMessage", exception.getMessage());
+                    request.getRequestDispatcher("/admin/error").forward(request, response);
+                })
+                ;
+
+        http
+                .logout()//로그아웃 처리
+                .logoutUrl("/logout")// 로그아웃 처리 URL
+                .logoutSuccessUrl("/")//로그아웃 성공 후 이동페이지
+        ;
+
+        http
+                .exceptionHandling()
+                .authenticationEntryPoint((httpServletRequest, httpServletResponse, e) -> {  // 인증 실패 시 처리
+                    System.out.println("인증 실패");
+                    httpServletResponse.sendRedirect("/");
+                })
+                .accessDeniedHandler((httpServletRequest, httpServletResponse, e) -> {// 인가 실패 시 처리
+                        System.out.println("인가 실패");
+                        httpServletResponse.sendRedirect("/");
+                })
+        ;
         return http.build();
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/configuration/auth/SecurityConfiguration.java
+++ b/src/main/java/com/chainsmoker/marronnier/configuration/auth/SecurityConfiguration.java
@@ -21,7 +21,7 @@ public class SecurityConfiguration {
         http.csrf().disable();
         http.authorizeRequests()
                 .antMatchers("/","/auth/**", "/css/**", "/images/**",
-                "/js/**", "/h2-console/**","/login/**").permitAll()
+                "/js/**", "/h2-console/**","/login/**", "/admin/regist", "/admin/login").permitAll()
                 .antMatchers("/basket/**", "/profile/**", "/find/**", "/feed/**").hasRole(Role.MEMBER.name())
                 .anyRequest().authenticated()
 //			    .antMatchers("/**").authenticated() // 인가된 사용자만 접근 가능하도록 설정

--- a/src/main/resources/templates/admin/error.html
+++ b/src/main/resources/templates/admin/error.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <h1 align="center">관리자 로그인 실패</h1>
+    <h3 align="center" th:text="${ errorMessage }"></h3>
+    <div align="center">
+        <button onclick="location.href='/admin/login'">다시 로그인하러 가기</button>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -5,6 +5,7 @@
     <title>Title</title>
 </head>
 <body>
-
+    <h1 align="center">관리자 홈화면 페이지</h1>
+    <h3 align="center" th:text="|${adminName} 관리자님 환영합니다.|"></h3>
 </body>
 </html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h1 align="center">관리자 로그인 페이지</h1>
+<form action="/admin/login" method="post">
+    관리자 ID : <input type="text" name="loginId" placeholder="Admin ID"/> <br>
+    관리자 비밀번호 : <input type="password" name="password"/> <br>
+    <button type="submit">제출</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/admin/regist.html
+++ b/src/main/resources/templates/admin/regist.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <h1 align="center">관리자 회원가입 페이지</h1>
+    <form action="/admin/regist" method="post">
+        관리자 ID : <input type="text" name="loginId" placeholder="Admin ID"/> <br>
+        관리자 이름 : <input type="text" name="name" placeholder="Admin Name"/> <br>
+        관리자 비밀번호 : <input type="password" name="password"/> <br>
+        <button type="submit">제출</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #73 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 인증을 받지 않은 사용자가 도메인으로 접근 시 카카오 계정 로그인 화면이 출력되는 문제를 해결했습니다.
  - Spring Security의 필터 체인의 구조를 이해할 필요가 있습니다.
![image](https://github.com/chain-smoker/Marronnier/assets/19159759/32ce1406-3dab-4e07-9c77-b5f4646019d0)

위 문제점은 위 그림의 `ExceptionTranslationFilter` 필터 체인의 Authorization 인터페이스의 AuthenticationEntryPoint 메소드와 `AccessDeniedHandler` 메소드를 오버라이딩하여 우리의 프로젝트에 맞게 메소드를 구현하였습니다.

---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* Spring Security를 통해 관리자 계정 로그인 구현
* Spring Security에서 관리하는 사용자 정보용 인터페이스인 UserDetails를 implements하여 AdminDetail 클래스에서 로그인 후 어드민 계정을 관리합니다.
* 관리자 계정 생성 시 Spring Security에서 제공하는 BCryptPasswordEncoder를 통해 사용자가 입력한 비밀번호를 단방향 암호화하여 저장합니다.
* Spring Security에서 제공하는 BCryptPasswordEncoder를 통해 사용자가 입력한 비밀번호와 데이터베이스 상에 저장된 관리자 비밀번호를 단향향 암호화하여 비교합니다.
* Spring Security를 통해 로그인을 성공할 경우 사용자의 정보는 단순히 Servlet Session에서 가져오면 안됩니다. 아래 예시처럼 사용자 정보를 가져와 주세요.
``` JAVA

 public String AdminMainView(Authentication authentication, Model model) {

        if(authentication.isAuthenticated()) {
            AdminDetail admin = (AdminDetail) authentication.getPrincipal();

            model.addAttribute("adminName", admin.getUsername());
            return "admin/home";
        } else {
            return "admin/login";
        }
    }
```
---

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 없음
