### PR TITLE
[Closes #60] 술바구니 칵테일 조주법 아이디를 통한 조회 구현

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/basket/query/application/dto/MemberCockTailBasketDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/basket/query/application/dto/MemberCockTailBasketDTO.java
@@ -1,6 +1,5 @@
 package com.chainsmoker.marronnier.basket.query.application.dto;
 
-import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -11,13 +10,17 @@ public class MemberCockTailBasketDTO {
     private final long memberId;
     private final long cockTailRecipeId;
     private final String cockTailRecipeName;
+    private final String cockTailRecipeDescription;
+    private final String cockTailRecipeDifficulty;
     private final String getCockTailRecipeImage;
     private final LocalDateTime createdDate;
 
-    public MemberCockTailBasketDTO(long memberId, long cockTailRecipeId, String cockTailRecipeName, LocalDateTime createdDate) {
+    public MemberCockTailBasketDTO(long memberId, long cockTailRecipeId, String cockTailRecipeName, String cockTailRecipeDescription, String cockTailRecipeDifficulty, LocalDateTime createdDate) {
         this.memberId = memberId;
         this.cockTailRecipeId = cockTailRecipeId;
         this.cockTailRecipeName = cockTailRecipeName;
+        this.cockTailRecipeDescription = cockTailRecipeDescription;
+        this.cockTailRecipeDifficulty = cockTailRecipeDifficulty;
         this.getCockTailRecipeImage = null;
         this.createdDate = createdDate;
     }

--- a/src/main/java/com/chainsmoker/marronnier/basket/query/application/service/FindBasketService.java
+++ b/src/main/java/com/chainsmoker/marronnier/basket/query/application/service/FindBasketService.java
@@ -1,9 +1,11 @@
 package com.chainsmoker.marronnier.basket.query.application.service;
 
 import com.chainsmoker.marronnier.basket.query.domain.entity.QueryBasket;
+import com.chainsmoker.marronnier.basket.query.domain.service.CocktailRecipeRequestService;
 import com.chainsmoker.marronnier.basket.query.domain.service.MemberRequestService;
 import com.chainsmoker.marronnier.basket.query.infra.repository.BasketMapper;
 import com.chainsmoker.marronnier.basket.query.application.dto.MemberCockTailBasketDTO;
+import com.chainsmoker.marronnier.cocktailrecipe.query.application.dto.FindCocktailRecipeDTO;
 import com.chainsmoker.marronnier.member.query.domain.entity.QueryMember;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,11 +18,13 @@ public class FindBasketService {
 
     private final BasketMapper basketMapper;
     private final MemberRequestService memberRequestService;
+    private final CocktailRecipeRequestService cocktailRecipeRequestService;
 
     @Autowired
-    public FindBasketService(BasketMapper basketMapper, MemberRequestService memberRequestService) {
+    public FindBasketService(BasketMapper basketMapper, MemberRequestService memberRequestService, CocktailRecipeRequestService cocktailRecipeRequestService) {
         this.basketMapper = basketMapper;
         this.memberRequestService = memberRequestService;
+        this.cocktailRecipeRequestService = cocktailRecipeRequestService;
     }
 
     public List<MemberCockTailBasketDTO> findByMemberId(long memberId) {
@@ -28,19 +32,17 @@ public class FindBasketService {
         List<MemberCockTailBasketDTO> memberCockTailBasketDTOList = new ArrayList<>();
         for (QueryBasket basket : baskets) {
             QueryMember member = memberRequestService.getMemberById(basket.getMemberId());
-//            MemberCockTailBasketDTO memberCockTailBasketDTO = MemberCockTailBasketDTO
-//                    .builder()
-//                    .cockTailRecipeId(basket.getCockTailRecipeId())
-//                    .cockTailRecipeName(member.getName())
-//                    .memberId(member.getId())
-//                    .createdDate(basket.getCreatedDate())
-//                    .build();
+            FindCocktailRecipeDTO cocktailRecipe = cocktailRecipeRequestService.getCocktailRecipeById(basket.getCockTailRecipeId());
+
             MemberCockTailBasketDTO memberCockTailBasketDTO = new MemberCockTailBasketDTO(
-                    basket.getMemberId(),
-                    basket.getCockTailRecipeId(),
-                    member.getName(),
+                    member.getId(),
+                    cocktailRecipe.getId(),
+                    cocktailRecipe.getName(),
+                    cocktailRecipe.getDescription(),
+                    cocktailRecipe.getDifficulty(),
                     basket.getCreatedDate()
             );
+
             memberCockTailBasketDTOList.add(memberCockTailBasketDTO);
         }
         return memberCockTailBasketDTOList;

--- a/src/main/java/com/chainsmoker/marronnier/basket/query/domain/service/CocktailRecipeRequestService.java
+++ b/src/main/java/com/chainsmoker/marronnier/basket/query/domain/service/CocktailRecipeRequestService.java
@@ -1,0 +1,8 @@
+package com.chainsmoker.marronnier.basket.query.domain.service;
+
+
+import com.chainsmoker.marronnier.cocktailrecipe.query.application.dto.FindCocktailRecipeDTO;
+
+public interface CocktailRecipeRequestService {
+    FindCocktailRecipeDTO getCocktailRecipeById(long cocktailRecipeId);
+}

--- a/src/main/java/com/chainsmoker/marronnier/basket/query/infra/service/CocktailRecipeRequestService.java
+++ b/src/main/java/com/chainsmoker/marronnier/basket/query/infra/service/CocktailRecipeRequestService.java
@@ -1,0 +1,20 @@
+package com.chainsmoker.marronnier.basket.query.infra.service;
+
+import com.chainsmoker.marronnier.cocktailrecipe.query.application.dto.FindCocktailRecipeDTO;
+import com.chainsmoker.marronnier.cocktailrecipe.query.application.service.FindCocktailRecipeService;
+import com.chainsmoker.marronnier.common.annotation.InfraService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@InfraService
+public class CocktailRecipeRequestService implements com.chainsmoker.marronnier.basket.query.domain.service.CocktailRecipeRequestService {
+
+    private final FindCocktailRecipeService findCocktailRecipeService;
+    @Autowired
+    public CocktailRecipeRequestService(FindCocktailRecipeService findCocktailRecipeService) {
+        this.findCocktailRecipeService = findCocktailRecipeService;
+    }
+    @Override
+    public FindCocktailRecipeDTO getCocktailRecipeById(long cocktailRecipeId) {
+        return findCocktailRecipeService.findByCocktailRecipeId(cocktailRecipeId);
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/like/command/domain/aggregate/vo/likevo.java
+++ b/src/main/java/com/chainsmoker/marronnier/like/command/domain/aggregate/vo/likevo.java
@@ -1,4 +1,28 @@
 package com.chainsmoker.marronnier.like.command.domain.aggregate.vo;
 
-public class likevo {
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import java.io.Serializable;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+@EqualsAndHashCode
+public class LikeVO implements Serializable {
+
+    @Column(nullable = false, name = "feed_id")
+    long feedId;
+    @Column(nullable = false, name = "member_id")
+    long memberId;
+
+    public LikeVO(long feedId, long memberId) {
+        this.feedId = feedId;
+        this.memberId = memberId;
+    }
 }

--- a/src/main/resources/templates/basket/memberBaskets.html
+++ b/src/main/resources/templates/basket/memberBaskets.html
@@ -5,15 +5,19 @@
     <title>member's Basket</title>
 </head>
 <body>
-<table>
-  <tr>
+<table border="1">
+  <tr align ="center">
       <th>칵테일 ID</th>
       <th>칵테일 이름</th>
+      <th>칵테일 설명</th>
+      <th>칵테일 제작 난이도</th>
       <th>추가 날짜</th>
   </tr>
-  <tr th:each="basket : ${memberCockTailBaskets}">
+  <tr th:each="basket : ${memberCockTailBaskets}" align ="center">
       <td th:text="${basket.getCockTailRecipeId()}">
     <td th:text="${basket.getCockTailRecipeName()}"></td>
+    <td th:text="${basket.getCockTailRecipeDescription()}"></td>
+      <td th:text="${basket.getCockTailRecipeDifficulty()}"></td>
     <td th:text="${basket.getCreatedDate()}"></td>
   </tr>
 </table>


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #60 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 인프라 서비스에서 구현할 때 도메인 인터페이스를 전체 패키지로만 가져와지는 문제 발생 (추후 수정 필요)
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* `FindBasketService`의 `findByMemberId` 메소드는 맴버가 저장한 술바구니에 속한 칵테일 조주법을 가져오는 기능입니다.
~~~ JAVA
 public List<MemberCockTailBasketDTO> findByMemberId(long memberId) {
        List<QueryBasket> baskets = basketMapper.findByMemberId(memberId);
        List<MemberCockTailBasketDTO> memberCockTailBasketDTOList = new ArrayList<>();
        for (QueryBasket basket : baskets) {
            QueryMember member = memberRequestService.getMemberById(basket.getMemberId());
            FindCocktailRecipeDTO cocktailRecipe = cocktailRecipeRequestService.getCocktailRecipeById(basket.getCockTailRecipeId());

            MemberCockTailBasketDTO memberCockTailBasketDTO = new MemberCockTailBasketDTO(
                    member.getId(),
                    cocktailRecipe.getId(),
                    cocktailRecipe.getName(),
                    cocktailRecipe.getDescription(),
                    cocktailRecipe.getDifficulty(),
                    basket.getCreatedDate()
            );

            memberCockTailBasketDTOList.add(memberCockTailBasketDTO);
        }
        return memberCockTailBasketDTOList;
~~~

위 코드에서 baskets의 `getMemberId`와 `getCockTailRecipeId` 메소드를 통해 술바구니 각각의 칵테일 조주법 정보를 가져옵니다.

* `FindBasketService` 는 맴버 정보와 칵테일 조주법 정보를 가져오기 위해 다른 도메인의 클래스를 바로 의존성을 주입받지 않고 domain 패키지의 service interface의 구현 클래스를 infra 패키지에 만들어 DIP 형태로 구현하였습니다.
---

# 관련 스크린샷

<img width="394" alt="CleanShot 2023-07-14 at 15 43 52@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/17e67da6-7fea-4009-9655-d8b048bb33ae">

---
* 기타 참고 사항이 있으면 참조한다.
*
---

# 테스트 계획 또는 완료 사항

---
* 테스트 관련 사항을 입력한다.
