### PR TITLE
[Closes #117] 맴버 카카오톡 프로필 이미지 저장

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/configuration/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/chainsmoker/marronnier/configuration/auth/CustomOAuth2UserService.java
@@ -6,7 +6,9 @@ import javax.servlet.http.HttpSession;
 import javax.transaction.Transactional;
 
 import com.chainsmoker.marronnier.member.command.application.dto.CreateMemberDTO;
+import com.chainsmoker.marronnier.member.command.application.dto.UpdateMemberDTO;
 import com.chainsmoker.marronnier.member.command.application.service.RegistMemberService;
+import com.chainsmoker.marronnier.member.command.application.service.UpdateMemberService;
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumType.Role;
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.Member;
 import com.chainsmoker.marronnier.member.query.application.dto.FindMemberDTO;
@@ -27,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class CustomOAuth2UserService  extends DefaultOAuth2UserService {
     private final RegistMemberService registMemberService;
     private final FindMemberService findMemberService;
+    private final UpdateMemberService updateMemberService;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -49,11 +52,13 @@ public class CustomOAuth2UserService  extends DefaultOAuth2UserService {
         FindMemberDTO member = findMemberService.findByUid(attributes.getUid());
         SessionUser sessionUser = null;
         if (member == null) {
-            CreateMemberDTO createMemberDTO = new CreateMemberDTO(attributes.getUid(), attributes.getName(), Role.MEMBER);
+            CreateMemberDTO createMemberDTO = new CreateMemberDTO(attributes.getUid(), attributes.getName(), Role.MEMBER, attributes.getProfileImage());
             Member newMember = registMemberService.create(createMemberDTO);
             //sessionUser = SessionUser.builder().addId(newMember.getId()).name(newMember.getName()).build();
             sessionUser = SessionUser.builder(newMember.getId(), newMember.getName(), newMember.getRole()).build();
         } else {
+            UpdateMemberDTO updateMemberDTO = new UpdateMemberDTO(attributes.getProfileImage());
+            boolean updateMemberResult = updateMemberService.updateMemberInformation(member.getId(), updateMemberDTO);
             //sessionUser = SessionUser.builder().id(member.getId()).name(member.getName()).build();
             sessionUser = SessionUser.builder(member.getId(), member.getName(), member.getRole()).build();
         }

--- a/src/main/java/com/chainsmoker/marronnier/configuration/auth/OAuthAttributes.java
+++ b/src/main/java/com/chainsmoker/marronnier/configuration/auth/OAuthAttributes.java
@@ -12,14 +12,16 @@ public class OAuthAttributes {
     private final Map<String, Object> attributes;
     private final String nameAttributeKey;
     private final String name;
+    private final String profileImage;
     private final Long uid;
     private final Long id;
 
     @Builder
-    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, Long uid, String picture, Long id) {
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String profileImage, Long uid, String picture, Long id) {
         this.attributes = attributes;
         this.nameAttributeKey = nameAttributeKey;
         this.name = name;
+        this.profileImage = profileImage;
         this.uid = uid;
         this.id = id;
     }
@@ -35,11 +37,12 @@ public class OAuthAttributes {
 
     private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
         Long uid = (Long) attributes.get("id");
-        Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
-        Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
 
         return OAuthAttributes.builder()
                 .name((String) kakaoProfile.get("nickname"))
+                .profileImage((String) kakaoProfile.get("profile_image_url"))
                 .uid(uid)
                 .nameAttributeKey(userNameAttributeName)
                 .attributes(attributes)

--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/controller/UpdateMemberController.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/controller/UpdateMemberController.java
@@ -38,8 +38,8 @@ public class UpdateMemberController {
                 updateMap.get("address"),
                 updateMap.get("job"),
                 LocalDate.parse(updateMap.get("birthDate")),
-                GenderEnum.valueOf(updateMap.get("gender"))
-        );
+                GenderEnum.valueOf(updateMap.get("gender")),
+                updateMap.get("profileImage"));
         System.out.println("updateMemberDTO = " + updateMemberDTO);
 
         SessionUser member = (SessionUser) authentication.getPrincipal();

--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/dto/CreateMemberDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/dto/CreateMemberDTO.java
@@ -8,10 +8,12 @@ public class CreateMemberDTO {
     private Long UID;
     private String name;
     private Role role;
+    private String profileImage;
 
-    public CreateMemberDTO(Long UID, String name, Role role) {
+    public CreateMemberDTO(Long UID, String name, Role role, String profileImage) {
         this.UID = UID;
         this.name = name;
         this.role = role;
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/dto/UpdateMemberDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/dto/UpdateMemberDTO.java
@@ -11,12 +11,18 @@ public class UpdateMemberDTO {
     private String job;
     private LocalDate birthDate;
     private GenderEnum gender;
+    private String profileImage;
 
-    public UpdateMemberDTO(String address, String job, LocalDate birthDate, GenderEnum gender) {
+    public UpdateMemberDTO(String address, String job, LocalDate birthDate, GenderEnum gender, String profileImage) {
         this.address = address;
         this.job = job;
         this.birthDate = birthDate;
         this.gender = gender;
+        this.profileImage = profileImage;
+    }
+
+    public UpdateMemberDTO(String profileImage) {
+        this.profileImage = profileImage;
     }
 
     @Override

--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/service/RegistMemberService.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/service/RegistMemberService.java
@@ -1,6 +1,7 @@
 package com.chainsmoker.marronnier.member.command.application.service;
 
 import com.chainsmoker.marronnier.member.command.application.dto.CreateMemberDTO;
+import com.chainsmoker.marronnier.member.command.application.dto.UpdateMemberDTO;
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumType.PlatformEnum;
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.Member;
 import com.chainsmoker.marronnier.member.command.domain.repository.MemberRepository;
@@ -27,7 +28,8 @@ public class RegistMemberService {
                 memberDTO.getName(),
                 memberDTO.getUID(),
                 PlatformEnum.KAKAO,
-                memberDTO.getRole()
+                memberDTO.getRole(),
+                memberDTO.getProfileImage()
         );
         return memberRepository.save(memberEntity);
     }

--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/service/UpdateMemberService.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/service/UpdateMemberService.java
@@ -22,10 +22,21 @@ public class UpdateMemberService {
         Optional<Member> findMember = memberRepository.findById(memberId);
         if (findMember.isPresent()) {
             Member updateMember = findMember.get();
-            updateMember.setAddress(updateMemberDTO.getAddress());
-            updateMember.setGender(updateMemberDTO.getGender());
-            updateMember.setBirthDate(updateMemberDTO.getBirthDate());
-            updateMember.setJob(updateMemberDTO.getJob());
+            if (updateMemberDTO.getAddress() != null) {
+                updateMember.setAddress(updateMemberDTO.getAddress());
+            }
+            if (updateMemberDTO.getGender() != null) {
+                updateMember.setGender(updateMemberDTO.getGender());
+            }
+            if (updateMemberDTO.getBirthDate() != null) {
+                updateMember.setBirthDate(updateMemberDTO.getBirthDate());
+            }
+            if (updateMemberDTO.getJob() != null) {
+                updateMember.setJob(updateMemberDTO.getJob());
+            }
+            if (updateMemberDTO.getProfileImage() != null) {
+                updateMember.setProfileImage(updateMemberDTO.getProfileImage());
+            }
             return true;
         } else {
             return false;

--- a/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/entity/Member.java
@@ -31,6 +31,9 @@ public class Member extends BaseTimeEntity {
 
     private String address;
 
+    @Column(length = 100, name = "profile_image")
+    private String profileImage;
+
     private String job;
 
     @Enumerated(EnumType.STRING)
@@ -59,11 +62,16 @@ public class Member extends BaseTimeEntity {
         this.job = job;
     }
 
-    public Member(String name, long uid, PlatformEnum platform, Role role) {
+    public Member(String name, long uid, PlatformEnum platform, Role role, String profileImage) {
         this.name = name;
         this.UID = uid;
         this.platform = platform;
         this.role = role;
+        this.profileImage = profileImage;
+    }
+
+    public void setProfileImage(String profileImage) {
+        this.profileImage = profileImage;
     }
 
     public void setName(String name) {


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #117 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 카카오톡에서 사용자의 프로필 이미지를 불러와 저장합니다.
* 프로필 추가 정보 업데이트 서비스에 null 값 체크를 추가하였습니다.

~~~JAVA
if (updateMemberDTO.getAddress() != null) {
                updateMember.setAddress(updateMemberDTO.getAddress());
            }
            if (updateMemberDTO.getGender() != null) {
                updateMember.setGender(updateMemberDTO.getGender());
            }
            if (updateMemberDTO.getBirthDate() != null) {
                updateMember.setBirthDate(updateMemberDTO.getBirthDate());
            }
            if (updateMemberDTO.getJob() != null) {
                updateMember.setJob(updateMemberDTO.getJob());
            }
            if (updateMemberDTO.getProfileImage() != null) {
                updateMember.setProfileImage(updateMemberDTO.getProfileImage());
            }
~~~
---

# 관련 스크린샷
![CleanShot 2023-07-18 at 17 45 19](https://github.com/chain-smoker/Marronnier/assets/19159759/53814426-01aa-40b1-9ea2-ae8114438a62)

---
* `application-oauth.yml` 파일에서 `scope` 항목에 `profile_image` 을 추가해줘야 합니다.
~~~ YML
spring:
  security:
    oauth2:
      client:
        registration:
          kakao:
            client-id: 52633746f46de6b660035fb667837f1f
            redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
            client-authentication-method: POST
            authorization-grant-type: authorization_code
            scope: profile_nickname, profile_image #추가 영역
            client-name: Kakao
        provider:
          kakao:
            authorization-uri: https://kauth.kakao.com/oauth/authorize
            token-uri: https://kauth.kakao.com/oauth/token
            user-info-uri: https://kapi.kakao.com/v2/user/me
            user-name-attribute: id

~~~
---

# 테스트 계획 또는 완료 사항

---
* 없음
