### PR TITLE
[Closes #145] 사용자 정보 업데이트 옵션 처리 및 테스트 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client:2.7.11'
+    // https://mvnrepository.com/artifact/org.springframework.security/spring-security-test
+    testImplementation 'org.springframework.security:spring-security-test:5.5.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/controller/UpdateMemberController.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/controller/UpdateMemberController.java
@@ -10,6 +10,8 @@ import com.chainsmoker.marronnier.member.query.application.dto.FindMemberDTO;
 import com.chainsmoker.marronnier.member.query.application.service.FindMemberService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -43,13 +45,21 @@ public class UpdateMemberController {
     @PostMapping("update")
     public String updateMemberInformation(@RequestParam Map<String, String> updateMap, Authentication authentication) {
 
-        UpdateMemberDTO updateMemberDTO = new UpdateMemberDTO(
-                updateMap.get("address"),
-                updateMap.get("job"),
-                LocalDate.parse(updateMap.get("birthDate")),
-                GenderEnum.valueOf(updateMap.get("gender")),
-                updateMap.get("profileImage"));
-        System.out.println("updateMemberDTO = " + updateMemberDTO);
+        UpdateMemberDTO updateMemberDTO = new UpdateMemberDTO();
+        if (!updateMap.get("address").equals("")) {
+            updateMemberDTO.setAddress(updateMap.get("address"));
+        }
+        if (!updateMap.get("job").equals("")) {
+            updateMemberDTO.setJob(updateMap.get("job"));
+        }
+        if(!updateMap.get("birthDate").equals("")) {
+            updateMemberDTO.setBirthDate(LocalDate.parse(updateMap.get("birthDate")));
+        }
+        if(!updateMap.get("gender").equals("")) {
+            updateMemberDTO.setGender(GenderEnum.valueOf(updateMap.get("gender")));
+        }
+
+        System.out.println("sessionUser = " + authentication.getPrincipal());
 
         SessionUser member = (SessionUser) authentication.getPrincipal();
         long memberId = member.getId();

--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/dto/UpdateMemberDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/dto/UpdateMemberDTO.java
@@ -2,16 +2,20 @@ package com.chainsmoker.marronnier.member.command.application.dto;
 
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumType.GenderEnum;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDate;
 
 @Getter
+@Setter
 public class UpdateMemberDTO {
     private String address;
     private String job;
     private LocalDate birthDate;
     private GenderEnum gender;
     private String profileImage;
+
+    public UpdateMemberDTO() {}
 
     public UpdateMemberDTO(String address, String job, LocalDate birthDate, GenderEnum gender, String profileImage) {
         this.address = address;

--- a/src/main/resources/templates/member/additional.html
+++ b/src/main/resources/templates/member/additional.html
@@ -109,10 +109,10 @@
                         </div>
                         <div class="main-info header-text"><h4>보다 정확한 추천을 위해 회원님의 추가 정보를 알려주세요!</h4>></div>
                         <form action="/member/update" method="post">
-                            <h4 class="heading-section">거주지</h4> <input class="input-group-text" type="text" name="address" id="address_kakao" readonly style="width: 30%"> <br>
-                            <h4 class="heading-section">직업</h4> <input class="input-group-text" type="text" name="job"><br>
-                            <h4 class="heading-section">생년월일</h4> <input class="input-group-text" type="date" name="birthDate"><br>
-                            <select name="gender" id="gender" class="btn btn-secondary btn-lg dropdown-toggle">
+                            <h4 class="heading-section ">거주지</h4> <input class="input-group-text" type="text" name="address" id="address_kakao" readonly style="width: 30%"> <br>
+                            <h4 class="heading-section ">직업</h4> <input class="input-group-text" type="text" name="job"><br>
+                            <h4 class="heading-section ">생년월일</h4> <input class="input-group-text" type="date" name="birthDate"><br>
+                            <select name="gender" id="gender" class="btn btn-secondary btn-lg dropdown-toggle required">
                                 <option class="dropdown-item" value="">성별 선택</option>
                                 <option class="dropdown-item" value="MALE">남성</option>
                                 <option class="dropdown-item" value="FEMALE">여성</option>

--- a/src/test/java/com/chainsmoker/marronnier/basket/CompositeKeyBasketTests.java
+++ b/src/test/java/com/chainsmoker/marronnier/basket/CompositeKeyBasketTests.java
@@ -1,4 +1,4 @@
-package com.chainsmoker.marronnier;
+package com.chainsmoker.marronnier.basket;
 
 
 import com.chainsmoker.marronnier.basket.command.application.dto.CreateBasketDTO;

--- a/src/test/java/com/chainsmoker/marronnier/member/ProfileUpdateTests.java
+++ b/src/test/java/com/chainsmoker/marronnier/member/ProfileUpdateTests.java
@@ -1,0 +1,120 @@
+package com.chainsmoker.marronnier.member;
+
+import com.chainsmoker.marronnier.common.handler.OAuth2SuccessHandler;
+import com.chainsmoker.marronnier.configuration.auth.CustomOAuth2UserService;
+import com.chainsmoker.marronnier.configuration.auth.SessionUser;
+import com.chainsmoker.marronnier.member.command.application.service.UpdateMemberService;
+import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumType.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.MediaType;
+
+
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.stream.Stream;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+
+@SpringBootTest
+@AutoConfigureDataJpa
+@ComponentScan(basePackages = "com.chainsmoker.marronnier.configuration.auth") // 커스텀한 security 패키지 주소
+public class ProfileUpdateTests {
+
+    private MockMvc mvc;
+
+    @MockBean
+    UpdateMemberService updateMemberService;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @MockBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockBean
+    private OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @BeforeEach
+    public void setup(@Autowired WebApplicationContext context) {
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    private static Stream<Arguments> updateAdditionalInfo() {
+        return Stream.of(
+                Arguments.of(
+                        "경기도 성남시",
+                        "",
+                        "",
+                        ""
+                ),
+                Arguments.of(
+                        "경기도 성남시",
+                        "힉생",
+                        "",
+                        ""
+                ),
+                Arguments.of(
+                        "경기도 성남시",
+                        "힉생",
+                        "1998-01-09",
+                        ""
+                ),
+                Arguments.of(
+                        "경기도 성남시",
+                        "힉생",
+                        "1998-01-09",
+                        "MALE"
+                )
+
+        );
+    }
+
+
+    @ParameterizedTest(name = "사용자 추가 정보 업데이트 테스트 | 주소 : {0} , 직업 : {1}, 생년월일 : {2}, 성별 : {3} ")
+    @MethodSource("updateAdditionalInfo")
+    @WithMockUser
+    void testUpdateAdditionalTests(String address, String job, String birthDate, String gender) throws Exception {
+
+        MultiValueMap<String, String> updateMap = new LinkedMultiValueMap<>();
+
+        updateMap.add("address", address);
+        updateMap.add("job", job);
+        updateMap.add("birthDate", birthDate);
+        updateMap.add("gender", gender);
+
+        mvc.perform(post("/member/update")
+                        .with(oauth2Login()
+                                .oauth2User(
+                                        SessionUser
+                                                .builder(1,"정지원",Role.MEMBER,"")
+                                                .build()
+                                )
+                        )
+                        .params(updateMap)
+                        .contentType(MediaType.MULTIPART_FORM_DATA) //보내는 데이터의 타입을 명시
+                )
+                .andExpect(status().is3xxRedirection());
+    }
+
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #145
---
# 어떤 위험이나 장애가 발견되었는지

---
* 프로필 업데이트에서 정보를 입력하지 않은 값 때문에 발생하는 에러를 수정하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 사용자가 입력한 DTO의 각 필드를 빈 문자열인지 체크하여 아닐 경우 dto에 값을 추가하였습니다.
* 컨트롤러와 spring security 테스트를 진행하였습니다.
---

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 사용자 추가 정보 업데이트 테스트를 진행하였습니다.

<img width="1496" alt="CleanShot 2023-07-21 at 17 30 21@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/f29de0db-22e1-411e-8ac9-82b69f257dc1">
