### PR TITLE
[Closes #154] 술바구니에서 피드 작성에 Path Variable로 칵테일 조주법 ID 전송

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/cocktailrecipe/command/application/service/RegistCocktailRecipeService.java
+++ b/src/main/java/com/chainsmoker/marronnier/cocktailrecipe/command/application/service/RegistCocktailRecipeService.java
@@ -21,6 +21,7 @@ public class RegistCocktailRecipeService {
                         recipeDTO.getDescription(),
                         recipeDTO.getClassification(),
                         recipeDTO.getAbv(),
+                        recipeDTO.getRecipe(),
                         recipeDTO.getDifficulty()
                 );
         cocktailRecipeRepository.save(cocktailRecipe);

--- a/src/main/resources/templates/member/profile.html
+++ b/src/main/resources/templates/member/profile.html
@@ -145,7 +145,7 @@
                                 <!--<li><h4>칵테일 설명</h4><span th:text="${basket.getCockTailRecipeDescription()}"></span></li>-->
                                 <li><h4>칵테일 제작 난이도</h4><span th:text="${basket.getCockTailRecipeDifficulty()}"></span></li>
                                 <li><h4>칵테일 추가 날짜</h4><span th:text="${basket.getCreatedDate()}"></span></li>
-                                <li><div class="main-border-button"><a href="/feed/write">피드 작성</a></div></li>
+                                <li><div class="main-border-button"><a th:href="@{/feed/write/{cocktailRecipeId}(cocktailRecipeId = ${basket.getCockTailRecipeId()})}">피드 작성</a></div></li>
                                 <li>
                                     <form action="/basket/delete" method="post">
                                                 <input th:value="${basket.getCockTailRecipeId()}" hidden="hidden" name="cockTailRecipeId">


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #154 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 피드 작성 시, 조주법의 ID를 path variable로 넘깁니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 조주법에 조주 방법이 추가되면서 `RegistCocktailRecipeService`의 `regist` 메소드에서 CocktailRecipe 엔티티 생성 시 해당 값을 넣는 부분이 빠져 추가하였습니다. @CodeJugller 


---

# 관련 스크린샷

<img width="738" alt="CleanShot 2023-07-21 at 19 58 06@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/e8ac9256-b3a0-4655-a652-deb8bd0dd385">

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 없음
