### PR TITLE
[#170] 프로필페이지 프로필 이미지, navbar 프로필 이미지 리사이징

### DIFF
--- a/src/main/resources/static/css/custom.css
+++ b/src/main/resources/static/css/custom.css
@@ -37,3 +37,9 @@
     background-color: #1f2122 !Important;
     border: solid 1px #ec6090;
 }
+
+.nav-item > a > img
+{
+    width: 30px;
+    height: 30px;
+}

--- a/src/main/resources/templates/basket/memberBaskets.html
+++ b/src/main/resources/templates/basket/memberBaskets.html
@@ -20,6 +20,7 @@
 
     <!-- Latest compiled JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+    <link href="/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Additional CSS Files -->
     <link rel="stylesheet" href="/css/fontawesome.css">
@@ -116,12 +117,12 @@
                             </div>
                             <div class="item" th:each="basket : ${baskets}">
                                 <ul>
-                                    <li><img th:src="${member.getProfileImage()}" alt="" class="templatemo-item"></li>
+                                    <li><img th:src="${member.getProfileImage()}" alt="" class="templatemo-item" style="width: 80px; height: 80px;"></li>
                                     <li><h4>칵테일 이름</h4><span th:text="${basket.getCockTailRecipeName()}"></span></li>
                                     <!--<li><h4>칵테일 설명</h4><span th:text="${basket.getCockTailRecipeDescription()}"></span></li>-->
                                     <li><h4>칵테일 제작 난이도</h4><span th:text="${basket.getCockTailRecipeDifficulty()}"></span></li>
                                     <li><h4>추가 날짜</h4><span th:text="${basket.getCreatedDate()}"></span></li>
-                                    <li><div class="main-border-button"><a th:href="@{/feed/write/{cocktailRecipeId}(cocktailRecipeId = ${basket.getCockTailRecipeId()})}">피드 작성</a></div></li>
+                                    <li><div class="main-border-button" style="margin-left: 30px;"><a th:href="@{/feed/write/{cocktailRecipeId}(cocktailRecipeId = ${basket.getCockTailRecipeId()})}">피드 작성</a></div></li>
                                     <li>
                                         <form action="/basket/delete" method="post">
                                             <input th:value="${basket.getCockTailRecipeId()}" hidden="hidden" name="cockTailRecipeId">
@@ -137,56 +138,54 @@
                         </div>
                     </div>
             <!-- ***** Gaming Library End ***** -->
-
-            <!-- ****** Pagination Start ******-->
-            <nav style="text-align: center;">
-                <!--표에 사용될 변수값 초기화 -->
-                <ul class="pagination"
-                    th:with="start=${T(java.lang.Math).floor(basketPages.number/10)*10 + 1},
+        </div>
+    </div>
+    <div class="row d-flex justify-content-center">
+        <!-- ****** Pagination Start ******-->
+        <div class="d-flex justify-content-center">
+            <!--표에 사용될 변수값 초기화 -->
+            <ul class="pagination"
+                th:with="start=${T(java.lang.Math).floor(basketPages.number/10)*10 + 1},
                     last=(${start + 9 < basketPages.totalPages ? start + 9 : basketPages.totalPages})">
-                    <th:block th:with="
+                <th:block th:with="
                 firstAddr=@{/basket(page=1)},
                 prevAddr=@{/basket(page=${basketPages.number})},
                 nextAddr=@{/basket(page=${basketPages.number + 2})},
                 lastAddr=@{/basket(page=${basketPages.totalPages})}">
-                        <li>
-                            <a th:href="${firstAddr}" aria-label="First">
-                                <span aria-hidden="true">First</span>
-                            </a>
-                        </li>
-                        <!-- 이전 페이지로 가기 버튼 -->
-                        <li th:class="${basketPages.first} ? 'disabled'">
-                            <a th:href="${basketPages.first} ? '#' :${prevAddr}"
-                               aria-label="Previous">
-                                <span aria-hidden="true">&lt;</span>
-                            </a>
-                        </li>
-                        <!--1,2,3,4,.. 등 페이지-->
-                        <li th:each="page: ${#numbers.sequence(start, last)}"
-                            th:class="${page == basketPages.number + 1} ? 'active'">
-                            <a th:text="${page}" th:href="@{/basket(page=${page})}"></a>
-                        </li>
-                        <!--다음 페이지로 -->
-                        <li th:class="${basketPages.last} ? 'disabled'">
-                            <a th:href="${basketPages.last} ? '#' : ${nextAddr}"
-                               aria-label="Next">
-                                <span aria-hidden="true">&gt;</span>
-                            </a>
-                        </li>
-                        <!--맨 마지막 페이지로 이동 -->
-                        <li>
-                            <a th:href="${lastAddr}" aria-label="Last">
-                                <span aria-hidden="true">Last</span>
-                            </a>
-                        </li>
-                    </th:block>
-                </ul>
-            </nav>
-
-
-
-            <!-- ****** Pagination End ******-->
+                    <li>
+                        <a th:href="${firstAddr}" aria-label="First">
+                            <span aria-hidden="true">First</span>
+                        </a>
+                    </li>
+                    <!-- 이전 페이지로 가기 버튼 -->
+                    <li th:class="${basketPages.first} ? 'disabled'">
+                        <a th:href="${basketPages.first} ? '#' :${prevAddr}"
+                           aria-label="Previous">
+                            <span aria-hidden="true">&lt;</span>
+                        </a>
+                    </li>
+                    <!--1,2,3,4,.. 등 페이지-->
+                    <li th:each="page: ${#numbers.sequence(start, last)}"
+                        th:class="${page == basketPages.number + 1} ? 'active'">
+                        <a th:text="${page}" th:href="@{/basket(page=${page})}"></a>
+                    </li>
+                    <!--다음 페이지로 -->
+                    <li th:class="${basketPages.last} ? 'disabled'">
+                        <a th:href="${basketPages.last} ? '#' : ${nextAddr}"
+                           aria-label="Next">
+                            <span aria-hidden="true">&gt;</span>
+                        </a>
+                    </li>
+                    <!--맨 마지막 페이지로 이동 -->
+                    <li>
+                        <a th:href="${lastAddr}" aria-label="Last">
+                            <span aria-hidden="true">Last</span>
+                        </a>
+                    </li>
+                </th:block>
+            </ul>
         </div>
+        <!-- ****** Pagination End ******-->
     </div>
 </div>
 

--- a/src/main/resources/templates/member/additional.html
+++ b/src/main/resources/templates/member/additional.html
@@ -109,7 +109,7 @@
                         </div>
                         <div class="main-info header-text"><h4>보다 정확한 추천을 위해 회원님의 추가 정보를 알려주세요!</h4>></div>
                         <form action="/member/update" method="post">
-                            <h4 class="heading-section ">거주지</h4> <input class="input-group-text" type="text" name="address" id="address_kakao" readonly style="width: 30%"> <br>
+                            <h4 class="heading-section ">거주지</h4> <input onclick="execDaumPostcode()" class="input-group-text" type="text" name="address" id="address_kakao" readonly style="width: 30%"> <br>
                             <h4 class="heading-section ">직업</h4> <input class="input-group-text" type="text" name="job"><br>
                             <h4 class="heading-section ">생년월일</h4> <input class="input-group-text" type="date" name="birthDate"><br>
                             <select name="gender" id="gender" class="btn btn-secondary btn-lg dropdown-toggle required">
@@ -146,9 +146,9 @@
     <script src="/js/popup.js"></script>
     <script src="/js/custom.js"></script>
 
-    <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+    <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
     <script>
-            document.getElementById("address_kakao").addEventListener("click", function() { //주소입력칸을 클릭하면
+        function execDaumPostcode() {
                 //카카오 지도 발생
                 new daum.Postcode({
                     oncomplete: function (data) { //선택시 입력값 세팅
@@ -157,7 +157,7 @@
                         document.querySelector("input[name=address]").focus(); //상세입력 포커싱
                     }
                 }).open();
-            });
+        }
     </script>
 </body>
 </html>

--- a/src/main/resources/templates/member/profile.html
+++ b/src/main/resources/templates/member/profile.html
@@ -107,12 +107,10 @@
                     <div class="col-lg-12">
                         <div class="main-profile ">
                             <div class="row">
-                                <div class="col-lg-4 align-self-center">
-                                    <img th:src="${member.getProfileImage()}" alt="" style="border-radius: 23px;">
-                                </div>
-                                <div class="col-lg-2 align-self-center">
-                                    <div class="main-info header-text">
-                                        <h4 th:text="${member.getName()}"></h4>
+                                <div class="col-lg-6 align-self-center">
+                                    <img th:src="${member.getProfileImage()}" alt="" style="border-radius: 23px; width: 200px; height: 200px;">
+                                    <div class="main-info header-text" style="margin-top: 20px; margin-left: 50px;">
+                                        <h5 th:text="${member.getName()}"></h5>
                                     </div>
                                 </div>
                                 <div class="col-lg-6 align-self-center">


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #170 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 술바구니 페이지에서 드롭다운이 작동하지 않던 문제를 해결하였습니다.
* 간헐적으로 추가 정보 중 거주지 입력 팝업이 작동하지 않던 문제를 해결하였습니다.

---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 네비게이션 바의 프로필 이미지를 리사이징 하였습니다.
* 사용자의 프로필 페이지에서 프로필 이미지를 리사이징하였습니다.
---

# 관련 스크린샷

<img width="125" alt="CleanShot 2023-07-25 at 21 14 54@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/5ce42a8f-c937-4a68-bfce-825116991581">

<img width="1507" alt="CleanShot 2023-07-25 at 21 14 48@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/6c9dfd0f-e590-474f-b44d-d5af65b450fc">



---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 없음
