### PR TITLE
[Closes #178] 피드 전체 조회 및 상세 조회시 cocktailName 출력 [Closes #179] 술바구니에서 피드 쓰기 페이지로 이동

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/feed/query/application/controller/QueryFeedController.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/application/controller/QueryFeedController.java
@@ -49,18 +49,16 @@ public class QueryFeedController {
         return "feed/feed";
     }
 
-    @GetMapping("/write")
-    public String moveToFeedWrite(Authentication authentication, Model model) {
+    @GetMapping("/write/{cocktailRecipeId}")
+    public String moveToFeedWrite(Authentication authentication, Model model,@PathVariable(name = "cocktailRecipeId") long cocktailId) {
         SessionUser sessionUser = (SessionUser) authentication.getPrincipal();
-        String memberName = sessionUser.getName();
-        long memberId = sessionUser.getId();
         FindMemberDTO member = queryFeedService.findMemberById(sessionUser.getId());
         boolean memberIsAuthenticated = authentication.isAuthenticated();
-
+        String cocktailName = queryFeedService.findCocktailNameById(cocktailId);
         model.addAttribute("member",member);
         model.addAttribute("memberIsAuthenticated", memberIsAuthenticated);
-        model.addAttribute("memberName", memberName);
-        model.addAttribute("memberId", memberId);
+        model.addAttribute("cocktailName",cocktailName);
+        model.addAttribute("cocktailId",cocktailId);
         return "feed/write";
     }
 
@@ -76,6 +74,7 @@ public class QueryFeedController {
         parameter.put("feedId",feedId);//feed Id
 
         QueryFeed queryFeed = findFeedService.findFeedById(feedId);
+        info.put("cocktailName", queryFeedService.findCocktailNameById(queryFeed.getCocktailId()));
         info.put("feed", queryFeed);//feed info
         info.put("memberId", memberId);//current user iD
         info.put("feedId",feedId);//feed Id

--- a/src/main/java/com/chainsmoker/marronnier/feed/query/application/dto/CheckFeedDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/application/dto/CheckFeedDTO.java
@@ -18,21 +18,13 @@ public class CheckFeedDTO {
     private String content;
     private int like;
     private String profileImage;
+    private String cocktailName;
 
     public CheckFeedDTO(QueryFeed feed){
         this.Id= feed.getId();
         this.memberId = feed.getMemberId();
         this.cocktailId = feed.getCocktailId() ;
         this.content = feed.getContent();
-    }
-    public CheckFeedDTO(QueryFeed feed,int like, String writer, String profileImage){
-        this.Id= feed.getId();
-        this.memberId = feed.getMemberId();
-        this.cocktailId = feed.getCocktailId() ;
-        this.content = feed.getContent();
-        this.like=like;
-        this.writer=writer;
-        this.profileImage = profileImage;
     }
 
     public void setWriter(String writer) {
@@ -45,5 +37,9 @@ public class CheckFeedDTO {
 
     public void setProfileImage(String profileImage) {
         this.profileImage = profileImage;
+    }
+
+    public void setCocktailId(Long cocktailId) {
+        this.cocktailId = cocktailId;
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/feed/query/domain/service/CheckCocktatilService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/domain/service/CheckCocktatilService.java
@@ -1,0 +1,7 @@
+package com.chainsmoker.marronnier.feed.query.domain.service;
+
+import com.chainsmoker.marronnier.cocktailrecipe.query.domain.entity.QueryCocktailRecipe;
+
+public interface CheckCocktatilService {
+    String findByCocktailId(long cocktailId);
+}

--- a/src/main/java/com/chainsmoker/marronnier/feed/query/domain/service/QueryFeedService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/domain/service/QueryFeedService.java
@@ -4,6 +4,7 @@ import com.chainsmoker.marronnier.feed.query.application.dto.CheckFeedDTO;
 import com.chainsmoker.marronnier.feed.query.domain.entity.QueryFeed;
 import com.chainsmoker.marronnier.member.query.application.dto.FindMemberDTO;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -13,15 +14,16 @@ import java.util.List;
 public class QueryFeedService {
     private final CheckMemberService checkMemberService;
     private final CheckLikeService checkLikeService;
+    private final CheckCocktatilService checkCocktatilService;
     @Autowired
-    public QueryFeedService(CheckMemberService checkMemberService, CheckLikeService checkLikeService) {
+    public QueryFeedService(CheckMemberService checkMemberService, CheckLikeService checkLikeService, CheckCocktatilService checkCocktatilService) {
         this.checkMemberService = checkMemberService;
         this.checkLikeService = checkLikeService;
+        this.checkCocktatilService = checkCocktatilService;
     }
 
     public List<CheckFeedDTO> saveInfo(List<QueryFeed> queryFeeds) {
         List<CheckFeedDTO> feedDTOS = new ArrayList<>();
-
         for (QueryFeed feed : queryFeeds) {
             CheckFeedDTO checkFeedDTO = new CheckFeedDTO(feed);
             feedDTOS.add(checkFeedDTO);
@@ -45,10 +47,17 @@ public class QueryFeedService {
         for(int i = 0 ; i <checkFeedDTOS.size(); i++){
             long feedId= checkFeedDTOS.get(i).getId();
             long memberId= checkFeedDTOS.get(i).getMemberId();
+            long cocktailId = checkFeedDTOS.get(i).getCocktailId();
             checkFeedDTOS.get(i).setLike(checkLikeService.numberOfLike(feedId));
             FindMemberDTO writer =checkMemberService.findById(memberId);
             checkFeedDTOS.get(i).setWriter(writer.getName());
             checkFeedDTOS.get(i).setProfileImage(writer.getProfileImage());
+            checkFeedDTOS.get(i).setCocktailName(findCocktailNameById(cocktailId));
         }
+    }
+
+
+    public String findCocktailNameById(long cocktailId){
+        return checkCocktatilService.findByCocktailId(cocktailId);
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/feed/query/infra/service/CheckCocktailService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/infra/service/CheckCocktailService.java
@@ -1,0 +1,19 @@
+package com.chainsmoker.marronnier.feed.query.infra.service;
+
+import com.chainsmoker.marronnier.cocktailrecipe.query.application.service.FindCocktailRecipeService;
+import com.chainsmoker.marronnier.feed.query.domain.service.CheckCocktatilService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CheckCocktailService implements CheckCocktatilService {
+    private final FindCocktailRecipeService cocktailRecipeService;
+
+    @Autowired
+    public CheckCocktailService(FindCocktailRecipeService cocktailRecipeService) {
+        this.cocktailRecipeService = cocktailRecipeService;
+    }
+    public String findByCocktailId(long cocktailId) {
+        return cocktailRecipeService.findByCocktailRecipeId(cocktailId).getName();
+    }
+}

--- a/src/main/resources/templates/feed/feed.html
+++ b/src/main/resources/templates/feed/feed.html
@@ -62,7 +62,7 @@
                     document.getElementsByClassName("feedContent")[0].textContent = data.feed.content;
                     document.getElementsByClassName("feedWriter")[0].textContent = data.feedWriter.name;
                     document.getElementsByClassName("writerProfile")[0].src=data.feedWriter.profileImage;
-                    document.getElementsByClassName("cocktailName")[0].textContent = data.feed.cocktailId;
+                    document.getElementsByClassName("cocktailName")[0].textContent = data.cocktailName;
                     document.getElementsByClassName("NumberOfLike")[0].textContent = data.NumberOfLike;
                     document.getElementsByClassName("like")[0].value = data.feedId;
                     document.getElementsByClassName("hate")[0].value = data.feedId;
@@ -198,7 +198,7 @@
                                     <div class="item">
                                         <img th:value="${feed.getId()}" th:src="${member.getProfileImage()}" alt="">
                                         <h4 th:text="@{'# '+${feed.getWriter()}}"></h4><br>
-                                        <h4><span th:text="${feed.getCocktailId()}"></span></h4>
+                                        <h4><span th:text="${feed.getCocktailName()}"></span></h4>
                                         <ul>
                                             <li ><i style="display: inline" class="fa fa-heart" ></i> <a th:text="@{' '+${feed.getLike()}}"></a> </li>
                                         </ul>

--- a/src/main/resources/templates/feed/write.html
+++ b/src/main/resources/templates/feed/write.html
@@ -97,23 +97,13 @@
     <div class="row">
         <div class="col-lg-12">
             <div class="page-content">
-
-<!--                피드 쓰러온 페이지입니다.-->
-<!--                <form action="/feed" method="post">-->
-<!--                    <input th:value="${memberName}" name="memberName" readonly><br>-->
-<!--                    <input th:value="${memberId}" name="memberId" readonly><br>-->
-<!--                    <input type="text" name="cocktailId">칵테일<br>-->
-<!--                    <input type="text" name="content">내용<br>-->
-<!--                    <button type="submit">완료</button>-->
-<!--                </form>-->
-
                 <form action="/feed" method="post">
 
                     <div class="mb-3 row">
                         <label for="writer" style="color: #d3d6d8" class="col-sm-2 col-form-label fw-semibold">작성자</label>
                         <div class="col-sm-10">
                             <input type="text" style="color: #d3d6d8" readonly class="form-control-plaintext fw-semibold" id="writer"
-                                   th:value="${memberName}"
+                                   th:value="${member.getName()}"
                                    name="memberName">
                         </div>
                     </div>
@@ -121,11 +111,12 @@
                         <label style="color: #d3d6d8" for="cocktail" class="col-sm-2 col-form-label fw-semibold">칵테일</label>
                         <div class="col-sm-10">
                             <input type="text" style="color: #d3d6d8" readonly class="form-control-plaintext fw-semibold" id="cocktail"
-                                   th:value="${memberId}" name="cocktailId">
+                                   th:value="${cocktailName}" name="cocktailName">
                         </div>
                     </div>
 
-                    <input th:value="${memberId}" name="memberId" hidden="hidden"><br>
+                    <input th:value="${member.getId()}" name="memberId" hidden="hidden"><br>
+                    <input th:value="${cocktailId}" name="cocktailId" hidden="hidden"><br>
 
                     <div class="mb-3 row">
                         <label for="inputContent" class="col-sm-2 col-form-label text-white fw-semibold">내용</label>


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #178 
* #179
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 피드 전체 보기 페이지에서 cocktail의 이름을 보여줌
* 피드 상세 보기 페이지에서 cocktail의 이름을 보여줌
* 술바구니에서 피드 쓰기 페이지로 이동
---

# 관련 스크린샷

---
* 
![image](https://github.com/chain-smoker/Marronnier/assets/74136791/44af728d-186e-4e9f-9f59-b4cb5bc8da32)
![image](https://github.com/chain-smoker/Marronnier/assets/74136791/7a66e8df-c801-4721-a3af-49116ce044a0)

---

# 테스트 계획 또는 완료 사항

---
* 테스트 관련 사항을 입력한다.
