### PR TITLE
[Closes #177] 사용자 생년월일 VO로 처리 및 예외 처리

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/controller/UpdateMemberController.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/controller/UpdateMemberController.java
@@ -5,6 +5,8 @@ import com.chainsmoker.marronnier.configuration.auth.SessionUser;
 import com.chainsmoker.marronnier.member.command.application.dto.UpdateMemberDTO;
 import com.chainsmoker.marronnier.member.command.application.service.UpdateMemberService;
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumType.GenderEnum;
+import com.chainsmoker.marronnier.member.command.domain.aggregate.vo.BirthDateVO;
+import com.chainsmoker.marronnier.member.command.domain.exception.BirthDateAfterException;
 import com.chainsmoker.marronnier.member.command.domain.service.FindMemberRequest;
 import com.chainsmoker.marronnier.member.query.application.dto.FindMemberDTO;
 import com.chainsmoker.marronnier.member.query.application.service.FindMemberService;
@@ -15,7 +17,12 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Map;
 
@@ -43,33 +50,39 @@ public class UpdateMemberController {
     }
 
     @PostMapping("update")
-    public String updateMemberInformation(@RequestParam Map<String, String> updateMap, Authentication authentication) {
+    public String updateMemberInformation(RedirectAttributes rttr, @RequestParam Map<String, String> updateMap, Authentication authentication)
+            throws ServletException, IOException {
+        try {
+            UpdateMemberDTO updateMemberDTO = new UpdateMemberDTO();
+            if (!updateMap.get("address").equals("")) {
+                updateMemberDTO.setAddress(updateMap.get("address"));
+            }
+            if (!updateMap.get("job").equals("")) {
+                updateMemberDTO.setJob(updateMap.get("job"));
+            }
+            if(!updateMap.get("birthDate").equals("")) {
+                updateMemberDTO.setBirthDate(new BirthDateVO(LocalDate.parse(updateMap.get("birthDate"))));
+            }
+            if(!updateMap.get("gender").equals("")) {
+                updateMemberDTO.setGender(GenderEnum.valueOf(updateMap.get("gender")));
+            }
 
-        UpdateMemberDTO updateMemberDTO = new UpdateMemberDTO();
-        if (!updateMap.get("address").equals("")) {
-            updateMemberDTO.setAddress(updateMap.get("address"));
-        }
-        if (!updateMap.get("job").equals("")) {
-            updateMemberDTO.setJob(updateMap.get("job"));
-        }
-        if(!updateMap.get("birthDate").equals("")) {
-            updateMemberDTO.setBirthDate(LocalDate.parse(updateMap.get("birthDate")));
-        }
-        if(!updateMap.get("gender").equals("")) {
-            updateMemberDTO.setGender(GenderEnum.valueOf(updateMap.get("gender")));
-        }
+            System.out.println("sessionUser = " + authentication.getPrincipal());
 
-        System.out.println("sessionUser = " + authentication.getPrincipal());
+            SessionUser member = (SessionUser) authentication.getPrincipal();
+            long memberId = member.getId();
 
-        SessionUser member = (SessionUser) authentication.getPrincipal();
-        long memberId = member.getId();
-
-        boolean updateMemberInformation = updateMemberService.updateMemberInformation(memberId, updateMemberDTO);
-        if (updateMemberInformation) {
-           return "redirect:/home";
-        } else {
+            boolean updateMemberInformation = updateMemberService.updateMemberInformation(memberId, updateMemberDTO);
+            if (updateMemberInformation) {
+                return "redirect:/home";
+            } else {
+                return "redirect:/member/info";
+            }
+        } catch (Exception exception) {
+            if (exception.getClass() == BirthDateAfterException.class) {
+                rttr.addFlashAttribute("errorMessage", exception.getMessage());
+            }
             return "redirect:/member/info";
         }
     }
-
 }

--- a/src/main/java/com/chainsmoker/marronnier/member/command/application/dto/UpdateMemberDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/application/dto/UpdateMemberDTO.java
@@ -1,6 +1,7 @@
 package com.chainsmoker.marronnier.member.command.application.dto;
 
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumType.GenderEnum;
+import com.chainsmoker.marronnier.member.command.domain.aggregate.vo.BirthDateVO;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,13 +12,13 @@ import java.time.LocalDate;
 public class UpdateMemberDTO {
     private String address;
     private String job;
-    private LocalDate birthDate;
+    private BirthDateVO birthDate;
     private GenderEnum gender;
     private String profileImage;
 
     public UpdateMemberDTO() {}
 
-    public UpdateMemberDTO(String address, String job, LocalDate birthDate, GenderEnum gender, String profileImage) {
+    public UpdateMemberDTO(String address, String job, BirthDateVO birthDate, GenderEnum gender, String profileImage) {
         this.address = address;
         this.job = job;
         this.birthDate = birthDate;

--- a/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/entity/Member.java
@@ -7,6 +7,7 @@ import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumTyp
 import java.time.LocalDate;
 
 import com.chainsmoker.marronnier.member.command.domain.aggregate.entity.EnumType.Role;
+import com.chainsmoker.marronnier.member.command.domain.aggregate.vo.BirthDateVO;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,8 +40,8 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private GenderEnum gender;
 
-    @Column(name = "birth_date")
-    private LocalDate birthDate;
+    @Embedded
+    private BirthDateVO birthDate;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -51,7 +52,7 @@ public class Member extends BaseTimeEntity {
     private Role role;
 
 
-    public Member(String name, Long uid, String address, GenderEnum gender, LocalDate birthDate, PlatformEnum platform, String job) {
+    public Member(String name, Long uid, String address, GenderEnum gender, BirthDateVO birthDate, PlatformEnum platform, String job) {
         this.name = name;
         this.UID = uid;
         this.address = address;
@@ -86,7 +87,7 @@ public class Member extends BaseTimeEntity {
         this.gender = gender;
     }
 
-    public void setBirthDate(LocalDate birthDate) {
+    public void setBirthDate(BirthDateVO birthDate) {
         this.birthDate = birthDate;
     }
 

--- a/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/vo/BirthDateVO.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/vo/BirthDateVO.java
@@ -1,0 +1,35 @@
+package com.chainsmoker.marronnier.member.command.domain.aggregate.vo;
+
+import com.chainsmoker.marronnier.member.command.domain.exception.BirthDateAfterException;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Embeddable
+public class BirthDateVO {
+
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
+
+    protected BirthDateVO() {
+    }
+
+    public BirthDateVO(LocalDate birthDate) {
+        LocalDate now = LocalDate.now();
+        if (birthDate.isBefore(now)) {
+            this.birthDate = birthDate;
+        } else {
+            throw new BirthDateAfterException("생년월일은 오늘 이전이어야 합니다.");
+        }
+    }
+
+    public LocalDate getBirthDate() {
+        return birthDate;
+    }
+
+    public String getFormattedBirthDate() {
+        return birthDate.format(DateTimeFormatter.ofPattern("YYYY년 MM월 dd일 HH시 mm분"));
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/vo/MemberVO.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/domain/aggregate/vo/MemberVO.java
@@ -1,4 +1,0 @@
-package com.chainsmoker.marronnier.member.command.domain.aggregate.vo;
-
-public class MemberVO {
-}

--- a/src/main/java/com/chainsmoker/marronnier/member/command/domain/exception/BirthDateAfterException.java
+++ b/src/main/java/com/chainsmoker/marronnier/member/command/domain/exception/BirthDateAfterException.java
@@ -1,0 +1,8 @@
+package com.chainsmoker.marronnier.member.command.domain.exception;
+
+public class BirthDateAfterException extends IllegalArgumentException {
+
+    public BirthDateAfterException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/resources/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mapper/member/MemberMapper.xml
@@ -7,7 +7,7 @@
     <result property="UID" column="uid"/>
     <result property="address" column="address" />
     <result property="gender" column="gender"/>
-    <result property="bitrhDate" column="bitrh_date"/>
+    <result property="birthDate" column="birth_date"/>
     <result property="platform" column="platform"/>
     <result property="createdDate" column="created_date"/>
     <result property="modifiedDate" column="modified_date"/>

--- a/src/main/resources/templates/member/additional.html
+++ b/src/main/resources/templates/member/additional.html
@@ -159,5 +159,14 @@
                 }).open();
         }
     </script>
+
+    <script th:inline="javascript">
+        window.onload = function () {
+            let exceptionMessage = [[${ errorMessage }]];
+            if(exceptionMessage !== null) {
+                alert(exceptionMessage);
+            }
+        }
+    </script>
 </body>
 </html>

--- a/src/test/java/com/chainsmoker/marronnier/member/BirthDateTests.java
+++ b/src/test/java/com/chainsmoker/marronnier/member/BirthDateTests.java
@@ -1,0 +1,50 @@
+package com.chainsmoker.marronnier.member;
+
+import com.chainsmoker.marronnier.member.command.application.dto.UpdateMemberDTO;
+import com.chainsmoker.marronnier.member.command.application.service.UpdateMemberService;
+import com.chainsmoker.marronnier.member.command.domain.aggregate.vo.BirthDateVO;
+import com.chainsmoker.marronnier.member.command.domain.exception.BirthDateAfterException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+@SpringBootTest
+@Transactional
+public class BirthDateTests {
+
+    @Autowired
+    private UpdateMemberService updateMemberService;
+
+    private static Stream<Arguments> getBirthDate() {
+        return Stream.of(
+                Arguments.of(
+                        "2023-08-31"
+                ),
+                Arguments.of(
+                        "2024-01-01"
+                )
+        );
+    }
+
+    @DisplayName("오늘 이후 생년월일 입력 시 BirthDateAfterException 발생하는지 확인")
+    @ParameterizedTest
+    @MethodSource("getBirthDate")
+    void testBirthDateExceptionTests(String date) {
+
+        Assertions.assertThrows(BirthDateAfterException.class, () -> {
+            new BirthDateVO(LocalDate.parse(date));
+        });
+    }
+
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #177 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 오늘 이후의 값을 생년월일에 입력할 수 있던 문제를 해결하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 생년월일을 VO로 처리하였습니다. 
* 만약 생년월일을 오늘 이후로 입력할 경우 `BirthDateAfterException` 을 발생시키도록 하였습니다.
---

# 관련 스크린샷

<img width="1507" alt="CleanShot 2023-07-26 at 18 02 20@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/77abf55c-9786-4607-b94d-1e0755301c7a">

<img width="1510" alt="CleanShot 2023-07-26 at 18 02 27@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/eed95d68-07aa-4dc7-864a-4281dc5be420">


---
* 클라이언트 단에서는 alert 창을 띄우도록 하였습니다.
---

# 테스트 계획 또는 완료 사항

<img width="1086" alt="CleanShot 2023-07-26 at 18 01 41@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/87b2566d-99d0-4d12-8ca7-f26bb435dcdf">

---
* 오늘 이후 생년월일 입력 시 BirthDateAfterException 발생하는지 확인하는 테스트 코드를 작성하였습니다.
