### PR TITLE
[Closes #183] 관리자 같은 ID 회원가입 방지

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
@@ -8,11 +8,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.sql.SQLIntegrityConstraintViolationException;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 @Controller
 @RequestMapping("/admin")
 public class CreateAdminController {

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
@@ -37,7 +37,7 @@ public class CreateAdminController {
         } catch (DataIntegrityViolationException exception) {
             String reasonValue = exception.getCause().getCause().getLocalizedMessage().split(" ")[2].replaceAll("'", "");
             String reasonKey = reasonValue.equals(createAdminDTO.getLoginId()) ? "관리자 아이디" : reasonValue.equals(createAdminDTO.getName()) ? "관리자 이름" : "";
-            String errorMessage = !reasonKey.equals("") ? "이미 존재하는 " + reasonKey + " 입니다." : "회원가입 중 에러가 발생하였습니다.";
+            String errorMessage = !reasonKey.equals("") ? "이미 존재하는 " + reasonKey + " 입니다." : "관리자 회원가입 중 에러가 발생하였습니다.";
             rttr.addFlashAttribute("errorMessage", errorMessage);
             return "redirect:/admin/regist";
         }

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
@@ -3,8 +3,15 @@ package com.chainsmoker.marronnier.admin.command.application.controller;
 import com.chainsmoker.marronnier.admin.command.application.dto.CreateAdminDTO;
 import com.chainsmoker.marronnier.admin.command.application.service.RegistAdminService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 @Controller
 @RequestMapping("/admin")
@@ -23,14 +30,30 @@ public class CreateAdminController {
     }
 
     @PostMapping("regist")
-    public String registAdmin(CreateAdminDTO createAdminDTO) {
-        // @ModelAttribute("adminName") String adminName, @ModelAttribute("loginId") String loginId, @ModelAttribute("password") String password
-        long addResult = registAdminService.create(createAdminDTO);
-        if (addResult > 0) {
-            return "redirect:/admin/login";
-        } else {
+    public String registAdmin(RedirectAttributes rttr, CreateAdminDTO createAdminDTO) {
+        try {
+            // @ModelAttribute("adminName") String adminName, @ModelAttribute("loginId") String loginId, @ModelAttribute("password") String password
+            long addResult = registAdminService.create(createAdminDTO);
+            if (addResult > 0) {
+                return "redirect:/admin/login";
+            } else {
+                return "redirect:/admin/regist";
+            }
+        } catch (DataIntegrityViolationException exception) {
+            String reasonValue = exception.getCause().getCause().getLocalizedMessage().split(" ")[2].replaceAll("'", "");
+            String reasonKey = reasonValue.equals(createAdminDTO.getLoginId()) ? "관리자 아이디" : reasonValue.equals(createAdminDTO.getName()) ? "관리자 이름" : "";
+            System.out.println("reasonKey = " + reasonKey);
+            rttr.addFlashAttribute("errorMessage", exception.getMessage());
             return "redirect:/admin/regist";
         }
     }
-
+    private <K, V> Set<K> getKeys(Map<K, V> map, V value) {
+        Set<K> keys = new HashSet<>();
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            if (entry.getValue().equals(value)) {
+                keys.add(entry.getKey());
+            }
+        }
+        return keys;
+    }
 }

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
@@ -43,7 +43,7 @@ public class CreateAdminController {
             String reasonValue = exception.getCause().getCause().getLocalizedMessage().split(" ")[2].replaceAll("'", "");
             String reasonKey = reasonValue.equals(createAdminDTO.getLoginId()) ? "관리자 아이디" : reasonValue.equals(createAdminDTO.getName()) ? "관리자 이름" : "";
             System.out.println("reasonKey = " + reasonKey);
-            rttr.addFlashAttribute("errorMessage", exception.getMessage());
+            rttr.addFlashAttribute("errorMessage", "이미 존재하는 " + reasonKey + " 입니다.");
             return "redirect:/admin/regist";
         }
     }

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/application/controller/CreateAdminController.java
@@ -42,18 +42,9 @@ public class CreateAdminController {
         } catch (DataIntegrityViolationException exception) {
             String reasonValue = exception.getCause().getCause().getLocalizedMessage().split(" ")[2].replaceAll("'", "");
             String reasonKey = reasonValue.equals(createAdminDTO.getLoginId()) ? "관리자 아이디" : reasonValue.equals(createAdminDTO.getName()) ? "관리자 이름" : "";
-            System.out.println("reasonKey = " + reasonKey);
-            rttr.addFlashAttribute("errorMessage", "이미 존재하는 " + reasonKey + " 입니다.");
+            String errorMessage = !reasonKey.equals("") ? "이미 존재하는 " + reasonKey + " 입니다." : "회원가입 중 에러가 발생하였습니다.";
+            rttr.addFlashAttribute("errorMessage", errorMessage);
             return "redirect:/admin/regist";
         }
-    }
-    private <K, V> Set<K> getKeys(Map<K, V> map, V value) {
-        Set<K> keys = new HashSet<>();
-        for (Map.Entry<K, V> entry : map.entrySet()) {
-            if (entry.getValue().equals(value)) {
-                keys.add(entry.getKey());
-            }
-        }
-        return keys;
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/Admin.java
+++ b/src/main/java/com/chainsmoker/marronnier/admin/command/domain/aggragate/entity/Admin.java
@@ -13,7 +13,7 @@ public class Admin {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 30)
+    @Column(length = 30, nullable = false ,unique = true)
     private String name;
 
     @Enumerated(EnumType.STRING)
@@ -23,7 +23,7 @@ public class Admin {
     @Column(nullable = false)
     private String password;
 
-    @Column(name = "login_id")
+    @Column(name = "login_id", nullable = false ,unique = true)
     private String loginId;
 
     public Admin() {}

--- a/src/main/resources/templates/admin/regist.html
+++ b/src/main/resources/templates/admin/regist.html
@@ -86,5 +86,14 @@
 <script src="/js/popup.js"></script>
 <script src="/js/custom.js"></script>
 
+<script th:inline="javascript">
+    window.onload = function () {
+        let exceptionMessage = [[${ errorMessage }]];
+        if(exceptionMessage !== null) {
+            alert(exceptionMessage);
+        }
+    }
+</script>
+
 </body>
 </html>

--- a/src/test/java/com/chainsmoker/marronnier/admin/DuplicateAdminIdAndNameTests.java
+++ b/src/test/java/com/chainsmoker/marronnier/admin/DuplicateAdminIdAndNameTests.java
@@ -1,0 +1,52 @@
+package com.chainsmoker.marronnier.admin;
+
+
+import com.chainsmoker.marronnier.admin.command.application.dto.CreateAdminDTO;
+import com.chainsmoker.marronnier.admin.command.application.service.RegistAdminService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Stream;
+
+@SpringBootTest
+@Transactional
+public class DuplicateAdminIdAndNameTests {
+
+    @Autowired
+    private RegistAdminService registAdminService;
+
+
+    private static Stream<Arguments> getAdmin() {
+        return Stream.of(
+                Arguments.of(
+                        "adminIdTest",
+                        "adminNameTest"
+                ),
+                Arguments.of(
+                        "adminIdTest2",
+                        "adminNameTest2"
+                )
+        );
+    }
+
+    @DisplayName("중복된 관리자 아이디 및 이름 예외 처리 확인 테스트")
+    @ParameterizedTest
+    @MethodSource("getAdmin")
+    void testDuplicateAdminIdAndNameTests(String adminId, String adminName) {
+
+        CreateAdminDTO createAdminDTO = new CreateAdminDTO(adminId, "1234", adminName);
+        registAdminService.create(createAdminDTO);
+
+        Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> registAdminService.create(createAdminDTO)
+        );
+    }
+
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #183 

---
# 어떤 위험이나 장애가 발견되었는지

---
* 관리자 회원가입 시 중복 아이디와 이름이 회원가입 되는 문제를 해결하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* `login_id` 와 `name` 컬럼에 `nullable = false` , `unique = true` 설정을 추가하였습니다.
---

# 관련 스크린샷
<img width="1507" alt="CleanShot 2023-07-27 at 13 51 18@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/49a6bf5a-a746-4ee2-af31-9f0af9c96e50">

<img width="1510" alt="CleanShot 2023-07-27 at 13 53 15@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/69fc2592-8a1f-4c1b-a447-afa9910b3286">


---
* 없음
---

# 테스트 계획 또는 완료 사항

<img width="1225" alt="CleanShot 2023-07-27 at 14 09 29@2x" src="https://github.com/chain-smoker/Marronnier/assets/19159759/0933e8a0-a9cd-439f-a71e-9f2c472e7858">

---
* 중복된 관리자 아이디 및 이름 예외 처리 확인 테스트 완료
