### PR TITLE
[#142] 칵테일 상세보기 페이지 조주법 추가

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/cocktailrecipe/query/application/dto/FindCocktailRecipeDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/cocktailrecipe/query/application/dto/FindCocktailRecipeDTO.java
@@ -21,6 +21,7 @@ public class FindCocktailRecipeDTO {
     private String description;
     private String classification;
     private String abv;
+    private String recipe;
     private String difficulty;
 
     public static FindCocktailRecipeDTO entityToDTO(QueryCocktailRecipe queryCocktailRecipe){
@@ -30,6 +31,7 @@ public class FindCocktailRecipeDTO {
         recipeDTO.setDescription(queryCocktailRecipe.getDescription());
         recipeDTO.setClassification(queryCocktailRecipe.getClassification());
         recipeDTO.setAbv(queryCocktailRecipe.getAbv());
+        recipeDTO.setRecipe(queryCocktailRecipe.getRecipe());
         recipeDTO.setDifficulty(String.valueOf(queryCocktailRecipe.getDifficulty()));
         return recipeDTO;
     }
@@ -42,6 +44,7 @@ public class FindCocktailRecipeDTO {
                 ", description='" + description + '\'' +
                 ", classification='" + classification + '\'' +
                 ", abv='" + abv + '\'' +
+                ", recipe='" + recipe + '\'' +
                 ", difficulty='" + difficulty + '\'' +
                 '}';
     }

--- a/src/main/java/com/chainsmoker/marronnier/elementbyrecipe/query/application/controller/FindElementByRecipeController.java
+++ b/src/main/java/com/chainsmoker/marronnier/elementbyrecipe/query/application/controller/FindElementByRecipeController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller
@@ -28,15 +29,30 @@ public class FindElementByRecipeController {
     }
 
     @GetMapping("find/elementbyrecipe/{recipeId}")
-    public String findElementByRecipe(CocktailRecipeDTO recipeDTO, @PathVariable Long recipeId, Model model, Authentication authentication) {
+    public String findElementByRecipe(CocktailRecipeDTO cocktailRecipeDTO, @PathVariable Long recipeId, Model model, Authentication authentication) {
         // 수정  현재 사용한 FindElementDTO는 Element Package에서 구현된 것
         // 수정  이걸 ElementByRecipe에서 따로 DTO를 만들어서 할까??
-        if (recipeDTO.getName() == null) {
-            FindCocktailRecipeDTO recipe = findElementByRecipeService.findRecipeById(recipeId);
-            model.addAttribute("recipe", recipe);
+        if (cocktailRecipeDTO.getName() == null) {
+            FindCocktailRecipeDTO cocktailRecipe = findElementByRecipeService.findRecipeById(recipeId);
+            String[] recipes=cocktailRecipe.getRecipe().split("-");
+            int recipesSize=recipes.length;
+            List<String> recipe=new ArrayList<>();
+            for (int i=0; i< recipesSize; i++){
+                recipe.add(recipes[i]);
+            }
+            model.addAttribute("recipes",recipe);
+            model.addAttribute("cocktailRecipe", cocktailRecipe);
         } else {
-            model.addAttribute("recipe", recipeDTO);
+            String[] recipes=cocktailRecipeDTO.getRecipe().split("-");
+            int recipesSize=recipes.length;
+            List<String> recipe=new ArrayList<>();
+            for (int i=0; i< recipesSize; i++){
+                recipe.add(recipes[i]);
+            }
+            model.addAttribute("s",recipe);
+            model.addAttribute("cocktailRecipe", cocktailRecipeDTO);
         }
+        
         SessionUser sessionUser = (SessionUser) authentication.getPrincipal();
         boolean memberIsAuthenticated = authentication.isAuthenticated();
         model.addAttribute("member", sessionUser);

--- a/src/main/java/com/chainsmoker/marronnier/elementbyrecipe/query/application/dto/CocktailRecipeDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/elementbyrecipe/query/application/dto/CocktailRecipeDTO.java
@@ -13,6 +13,7 @@ public class CocktailRecipeDTO {
     private String description;
     private String classification;
     private String abv;
+    private String recipe;
     private DifficultyEnum difficulty;
 
 }

--- a/src/main/resources/mapper/cocktail/FindCocktailRecipeMapper.xml
+++ b/src/main/resources/mapper/cocktail/FindCocktailRecipeMapper.xml
@@ -16,6 +16,7 @@
               , DESCRIPTION
               , CLASSIFICATION
               , ABV
+              , RECIPE
               , DIFFICULTY
         FROM
             COCKTAILRECIPE_TB
@@ -27,6 +28,7 @@
              , DESCRIPTION
              , CLASSIFICATION
              , ABV
+             , RECIPE
              , DIFFICULTY
         FROM COCKTAILRECIPE_TB WHERE id=#{cocktailrecipeId}
 

--- a/src/main/resources/templates/cocktail/find/elementByrecipe.html
+++ b/src/main/resources/templates/cocktail/find/elementByrecipe.html
@@ -83,7 +83,7 @@
             <div class="page-content">
                 <div class="game-details">
                     <div class="row">
-                    <!-- 칵테일 description -->
+                        <!-- 칵테일 description -->
                         <div class="col-lg-12" style="margin-bottom: 40px;">
                             <div class="content">
                                 <div class="row">
@@ -92,7 +92,7 @@
                                                     border-radius: 23px;
                                                     margin-bottom: 30px;">
                                         <div align="center">
-                                            <h1 th:text="${recipe.getName()}"/>
+                                            <h1 th:text="${cocktailRecipe.getName()}"/>
                                         </div>
                                     </div>
                                     <div align="left" style="width: 50%">
@@ -113,9 +113,9 @@
                                         </th:block>
                                     </div>
                                     <div class="col-lg-12">
-                                        <h4 th:text="${recipe.getDescription()}"/>
+                                        <h4 th:text="${cocktailRecipe.getDescription()}"/>
                                     </div>
-                                    <form th:action="@{'/basket/add/'+${recipe.getId()}}" method="post">
+                                    <form th:action="@{'/basket/add/'+${cocktailRecipe.getId()}}" method="post">
                                         <button type="submit" class="customBtn">
                                             <div class="main-border-button">
                                                 <a class="customLink">술바구니에 추가하기!</a>
@@ -129,15 +129,15 @@
                         <div class="col-lg-12">
                             <div class="content">
                                 <div class="row" style="text-align: center">
-                                    <th:block th:each="element : ${elements}">
-                                    <div style="background-color: #27292a;
+                                    <th:block th:each="recipe : ${recipes}">
+                                        <div style="background-color: #27292a;
                                                         padding: 30px 0;
                                                         margin-bottom: 30px;
                                                         border-radius: 15px;
                                                         text-align: center">
-                                        <h4 th:text="${element.getName()}"/>
-                                    </div>
-                                </th:block>
+                                            <h4 th:text="${recipe}"/>
+                                        </div>
+                                    </th:block>
                                 </div>
                             </div>
                         </div>

--- a/src/test/java/com/chainsmoker/marronnier/cocktail/CokctailRecipeTests.java
+++ b/src/test/java/com/chainsmoker/marronnier/cocktail/CokctailRecipeTests.java
@@ -1,0 +1,37 @@
+package com.chainsmoker.marronnier.cocktail;
+
+import com.chainsmoker.marronnier.cocktailrecipe.query.application.dto.FindCocktailRecipeDTO;
+import com.chainsmoker.marronnier.cocktailrecipe.query.application.service.FindCocktailRecipeService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@SpringBootTest
+public class CokctailRecipeTests {
+
+    @Autowired
+    private FindCocktailRecipeService findCocktailRecipeService;
+
+    private static Stream<Arguments> getCocktailRecipeId(){
+        return Stream.of(
+                Arguments.of(
+                    1
+                )
+        );
+    }
+
+    @DisplayName("id로 cocktail조회 시 recipe 컬럼의 내용이 제대로 가져와지는지")
+    @ParameterizedTest
+    @MethodSource("getCocktailRecipeId")
+    void checkIdByRecipeTests(long cocktailId){
+        FindCocktailRecipeDTO cocktail = findCocktailRecipeService.findByCocktailRecipeId(cocktailId);
+        Assertions.assertNotNull(cocktail.getRecipe());
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #142 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
<img width="397" alt="image" src="https://github.com/chain-smoker/Marronnier/assets/136034038/21e4784d-f083-4f3c-916a-d28695f9729a">

* 타임리프를 사용하여 반복해서 출력하기 위해 다음과 같이 List에 옮겨담는 과정이 있었는데 혹시나 더 좋은 방법이 생각나시면 commnet 바랍니다.

---

# 관련 스크린샷

---
<img width="1016" alt="image" src="https://github.com/chain-smoker/Marronnier/assets/136034038/d30b93a5-93c5-41f1-9e36-ce5dc77ec350">

---

# 테스트 계획 또는 완료 사항

---
<img width="618" alt="image" src="https://github.com/chain-smoker/Marronnier/assets/136034038/4898fd81-068b-4b3b-a251-4822c5c4a870">

* 칵테일 ID로 조회했을 때 recipe값이 제대로 가져와지는지 확인했습니다.
---
