### PR TITLE
[Closes #188] 피드 작성시 사진 추가 기능 [Closes #191] 피드 전체 조회 및 상세 조회시 사진 로드 기능 [Closes #192] 사용자가 사진을 업로드 하지 않았을 때 default 사진 설정

### DIFF
--- a/src/main/java/com/chainsmoker/marronnier/feed/command/application/controller/FeedController.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/command/application/controller/FeedController.java
@@ -5,13 +5,17 @@ import com.chainsmoker.marronnier.feed.command.application.dto.CreateFeedDTO;
 import com.chainsmoker.marronnier.feed.command.application.dto.UpdateFeedDTO;
 import com.chainsmoker.marronnier.feed.command.application.service.FeedDeleteService;
 import com.chainsmoker.marronnier.feed.command.application.service.FeedInsertService;
+import com.chainsmoker.marronnier.feed.command.application.service.FeedPhotoService;
 import com.chainsmoker.marronnier.feed.command.application.service.FeedUpdateService;
 import com.chainsmoker.marronnier.feed.command.domain.service.FeedService;
+import com.chainsmoker.marronnier.photo.command.domain.aggregate.entity.EnumType.PhotoCategory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.Map;
 
 @Controller
@@ -21,19 +25,30 @@ public class FeedController {
     private final FeedInsertService feedInsertService;
     private final FeedUpdateService feedUpdateService;
     private final FeedDeleteService feedDeleteService;
+    private final FeedPhotoService feedPhotoService;
     @Autowired
-    public FeedController(FeedService feedService, FeedInsertService feedInsertService, FeedUpdateService feedUpdateService, FeedDeleteService feedDeleteService) {
+    public FeedController(FeedService feedService, FeedInsertService feedInsertService, FeedUpdateService feedUpdateService, FeedDeleteService feedDeleteService, FeedPhotoService feedPhotoService) {
         this.feedService = feedService;
         this.feedInsertService = feedInsertService;
         this.feedUpdateService = feedUpdateService;
         this.feedDeleteService = feedDeleteService;
+        this.feedPhotoService = feedPhotoService;
     }
 
     @PostMapping("")
-    public String writeFeed(Authentication authentication, @RequestParam Map<String, String> feedInfos) {
+    public String writeFeed(Authentication authentication, @RequestParam MultipartFile photo , @RequestParam Map<String, String> feedInfos) throws IOException {
         SessionUser sessionUser = (SessionUser) authentication.getPrincipal();
         CreateFeedDTO feedWriteDTO = feedService.saveData(feedInfos,sessionUser);//웹에서 받은 데이터 dto에 저장
+        System.out.println(photo);
         feedInsertService.saveFeed(feedWriteDTO);//db에 등록
+        if(photo!=null){
+            feedPhotoService.savePhoto(feedInsertService.saveFeed(feedWriteDTO),photo, PhotoCategory.valueOf("FEED"));
+        }else{
+            feedInsertService.saveFeed(feedWriteDTO);//db에 등록
+            /*
+            여기서 db에 저장된 사진을 갖다 넣는게 좋을지..
+             */
+        }
         //피드 작성하는 코드
         return "redirect:/feed";
     }

--- a/src/main/java/com/chainsmoker/marronnier/feed/command/application/service/FeedInsertService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/command/application/service/FeedInsertService.java
@@ -17,17 +17,17 @@ public class FeedInsertService {
         this.feedReposiroty = feedReposiroty;
     }
 
-    public void saveFeed(CreateFeedDTO feedWriteDTO) {
+    public long saveFeed(CreateFeedDTO feedWriteDTO) {
         MemberVO memberId = MemberVO.builder()
                 .memberId(feedWriteDTO.getMemberId()).build();
         CocktailRecipeVO cocktailRecipeVO = CocktailRecipeVO.builder()
                 .cocktailId(feedWriteDTO.getCocktailId()).build();
 
-        feedReposiroty.save(Feed.builder()
+        return feedReposiroty.save(Feed.builder()
                 .content(feedWriteDTO.getContent())
                 .memberId(memberId)
                 .cocktailId(cocktailRecipeVO)
                 .build()
-        );
+        ).getId();
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/feed/command/application/service/FeedPhotoService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/command/application/service/FeedPhotoService.java
@@ -1,0 +1,27 @@
+package com.chainsmoker.marronnier.feed.command.application.service;
+
+import com.chainsmoker.marronnier.feed.command.domain.service.InsertPhotoToFeedService;
+import com.chainsmoker.marronnier.photo.command.application.dto.PhotoDTO;
+import com.chainsmoker.marronnier.photo.command.domain.aggregate.entity.EnumType.PhotoCategory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+public class FeedPhotoService
+{
+    private final InsertPhotoToFeedService insertPhotoToFeedService;
+
+    @Autowired
+    public FeedPhotoService(InsertPhotoToFeedService insertPhotoToFeedService) {
+        this.insertPhotoToFeedService = insertPhotoToFeedService;
+    }
+
+    public PhotoDTO savePhoto(long feedId,
+                              MultipartFile photo,
+                              PhotoCategory photoCategory) throws IOException {
+        return insertPhotoToFeedService.savePhoto(feedId,photo,photoCategory);
+    }
+}

--- a/src/main/java/com/chainsmoker/marronnier/feed/command/domain/service/InsertPhotoToFeedService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/command/domain/service/InsertPhotoToFeedService.java
@@ -1,0 +1,13 @@
+package com.chainsmoker.marronnier.feed.command.domain.service;
+
+import com.chainsmoker.marronnier.photo.command.application.dto.PhotoDTO;
+import com.chainsmoker.marronnier.photo.command.domain.aggregate.entity.EnumType.PhotoCategory;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface InsertPhotoToFeedService {
+    PhotoDTO savePhoto(long feedId,
+                       MultipartFile photo,
+                       PhotoCategory photoCategory) throws IOException;
+}

--- a/src/main/java/com/chainsmoker/marronnier/feed/query/application/dto/CheckFeedDTO.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/application/dto/CheckFeedDTO.java
@@ -19,6 +19,7 @@ public class CheckFeedDTO {
     private int like;
     private String profileImage;
     private String cocktailName;
+    private String photoRoot;
 
     public CheckFeedDTO(QueryFeed feed){
         this.Id= feed.getId();
@@ -41,5 +42,9 @@ public class CheckFeedDTO {
 
     public void setCocktailId(Long cocktailId) {
         this.cocktailId = cocktailId;
+    }
+
+    public void setPhotoRoot(String photoRoot) {
+        this.photoRoot = photoRoot;
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/feed/query/application/service/FindFeedService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/application/service/FindFeedService.java
@@ -2,8 +2,11 @@ package com.chainsmoker.marronnier.feed.query.application.service;
 
 import com.chainsmoker.marronnier.feed.query.application.dto.CheckFeedDTO;
 import com.chainsmoker.marronnier.feed.query.domain.entity.QueryFeed;
+import com.chainsmoker.marronnier.feed.query.domain.service.CheckPhotoService;
 import com.chainsmoker.marronnier.feed.query.domain.service.QueryFeedService;
 import com.chainsmoker.marronnier.feed.query.infra.repository.FeedMapper;
+import com.chainsmoker.marronnier.photo.command.domain.aggregate.entity.EnumType.PhotoCategory;
+import com.chainsmoker.marronnier.photo.query.application.dto.FindPhotoDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,11 +16,13 @@ import java.util.List;
 public class FindFeedService {
     private final FeedMapper feedMapper;
     private final QueryFeedService queryFeedService;
+    private final CheckPhotoService checkPhotoService;
 
     @Autowired
-    public FindFeedService(FeedMapper feedMapper, QueryFeedService queryFeedService) {
+    public FindFeedService(FeedMapper feedMapper, QueryFeedService queryFeedService, CheckPhotoService checkPhotoService) {
         this.feedMapper = feedMapper;
         this.queryFeedService = queryFeedService;
+        this.checkPhotoService = checkPhotoService;
     }
 
     public List<CheckFeedDTO> findAllFeeds() {
@@ -36,5 +41,9 @@ public class FindFeedService {
         long feedMemberId = feedMapper.findFeedMemberIdByFeedId(feedId);
 
         return feedMemberId;
+    }
+
+    public List<FindPhotoDTO> findPhotoByIdAndCategory(long feedId, PhotoCategory photoCategory){
+        return checkPhotoService.findPhotoByIdAndCategory(feedId,photoCategory);
     }
 }

--- a/src/main/java/com/chainsmoker/marronnier/feed/query/domain/service/CheckPhotoService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/domain/service/CheckPhotoService.java
@@ -1,0 +1,10 @@
+package com.chainsmoker.marronnier.feed.query.domain.service;
+
+import com.chainsmoker.marronnier.photo.command.domain.aggregate.entity.EnumType.PhotoCategory;
+import com.chainsmoker.marronnier.photo.query.application.dto.FindPhotoDTO;
+
+import java.util.List;
+
+public interface CheckPhotoService {
+    List<FindPhotoDTO> findPhotoByIdAndCategory(long feedId, PhotoCategory photoCategory);
+}

--- a/src/main/java/com/chainsmoker/marronnier/feed/query/infra/service/CheckPhotoService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/infra/service/CheckPhotoService.java
@@ -1,0 +1,26 @@
+package com.chainsmoker.marronnier.feed.query.infra.service;
+
+import com.chainsmoker.marronnier.photo.command.domain.aggregate.entity.EnumType.PhotoCategory;
+import com.chainsmoker.marronnier.photo.query.application.dto.FindPhotoDTO;
+import com.chainsmoker.marronnier.photo.query.application.service.FindPhotoService;
+import org.checkerframework.checker.units.qual.A;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CheckPhotoService implements com.chainsmoker.marronnier.feed.query.domain.service.CheckPhotoService {
+
+    private final FindPhotoService findPhotoService;
+
+    @Autowired
+    public CheckPhotoService(FindPhotoService findPhotoService) {
+        this.findPhotoService = findPhotoService;
+    }
+
+    public List<FindPhotoDTO> findPhotoByIdAndCategory(long feedId, PhotoCategory photoCategory) {
+        return findPhotoService.findPhoto(feedId,photoCategory);
+    }
+
+}

--- a/src/main/java/com/chainsmoker/marronnier/feed/query/infra/service/InsertPhotoToFeedService.java
+++ b/src/main/java/com/chainsmoker/marronnier/feed/query/infra/service/InsertPhotoToFeedService.java
@@ -1,0 +1,25 @@
+package com.chainsmoker.marronnier.feed.query.infra.service;
+
+import com.chainsmoker.marronnier.photo.command.application.dto.PhotoDTO;
+import com.chainsmoker.marronnier.photo.command.application.service.InsertPhotoService;
+import com.chainsmoker.marronnier.photo.command.domain.aggregate.entity.EnumType.PhotoCategory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+public class InsertPhotoToFeedService implements com.chainsmoker.marronnier.feed.command.domain.service.InsertPhotoToFeedService {
+    private final InsertPhotoService insertPhotoService;
+    @Autowired
+    public InsertPhotoToFeedService(InsertPhotoService insertPhotoService) {
+        this.insertPhotoService = insertPhotoService;
+    }
+
+    public PhotoDTO savePhoto(long feedId,
+                              MultipartFile photo,
+                              PhotoCategory photoCategory) throws IOException {
+        return insertPhotoService.insertPhoto(feedId,photo,photoCategory);
+    }
+}

--- a/src/main/resources/templates/feed/feed.html
+++ b/src/main/resources/templates/feed/feed.html
@@ -61,13 +61,14 @@
                     }
                     document.getElementsByClassName("feedContent")[0].textContent = data.feed.content;
                     document.getElementsByClassName("feedWriter")[0].textContent = data.feedWriter.name;
-                    document.getElementsByClassName("writerProfile")[0].src=data.feedWriter.profileImage;
+                    document.getElementsByClassName("writerProfile")[0].src = data.feedWriter.profileImage;
                     document.getElementsByClassName("cocktailName")[0].textContent = data.cocktailName;
                     document.getElementsByClassName("NumberOfLike")[0].textContent = data.NumberOfLike;
                     document.getElementsByClassName("like")[0].value = data.feedId;
                     document.getElementsByClassName("hate")[0].value = data.feedId;
                     document.getElementsByClassName("deleteFeed")[0].action = "/feed/delete/" + id;
                     document.getElementsByClassName("updateFeed")[0].action = "/feed/update/" + id;
+                    document.getElementById("photo").src = data.photo;
 
                 },
                 error: function (xhr, status, error) {
@@ -196,11 +197,12 @@
                                 <div data-bs-toggle="modal" data-bs-target="#exampleModal"
                                      th:each="feed:${feeds}" class="col-lg-4 col-sm-6" onclick="onClick(this)">
                                     <div class="item">
-                                        <img th:value="${feed.getId()}" th:src="${member.getProfileImage()}" alt="">
+                                        <img th:value="${feed.getId()}" th:src="${feed.getPhotoRoot()}" alt="">
                                         <h4 th:text="@{'# '+${feed.getWriter()}}"></h4><br>
                                         <h4><span th:text="${feed.getCocktailName()}"></span></h4>
                                         <ul>
-                                            <li ><i style="display: inline" class="fa fa-heart" ></i> <a th:text="@{' '+${feed.getLike()}}"></a> </li>
+                                            <li><i style="display: inline" class="fa fa-heart"></i> <a
+                                                    th:text="@{' '+${feed.getLike()}}"></a></li>
                                         </ul>
                                     </div>
                                 </div>
@@ -230,10 +232,11 @@
         <div class="modal-content">
 
 
-<!--modal header start-->
+            <!--modal header start-->
             <div class="modal-header border-0" style="background-color: #1F2122">
                 <span><img style="border-radius: 50%; height: 30px;width: 30px" class="writerProfile" src="">
-                        <span class="feedWriter" style="margin-left: 5px; color: white;font-size: 20px;margin-top: 5px"></span></span>
+                        <span class="feedWriter"
+                              style="margin-left: 5px; color: white;font-size: 20px;margin-top: 5px"></span></span>
                 <a type="button" class="active" data-bs-dismiss="modal">확인</a>
             </div>
             <!--modal header end-->
@@ -242,30 +245,34 @@
             <!--modal body start-->
 
             <div class="modal-body border-0" style="background-color: #27292A">
-                <svg class="bd-placeholder-img rounded mx-auto d-block" width="250" height="250"
-                     xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: 200x200"
-                     preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                    <rect width="100%" height="100%" fill="#868e96"></rect>
-                    <text x="50%" y="50%" fill="#dee2e6" dy=".3em">200x200</text>
-                </svg>
+                <div class="d-flex justify-content-center">
+                    <div style="margin-left: auto;margin-right: auto; display: inline-block;" class="text-center">
+                        <img id="photo" class="rounded" width="250" height="250" src="">
+                    </div>
+                </div>
+
                 <div class="d-flex justify-content-center">
                     <p class="cocktailName" style="color: white;">술이름</p>
                 </div>
                 <div class="d-flex justify-content-center">
-                <p class="feedContent" style="color: whitesmoke"></p>
+                    <p class="feedContent" style="color: whitesmoke"></p>
                 </div>
 
                 <div style="margin-top: 20px" class="d-flex justify-content-center">
                     <div class="no1">
-                                <button style="background-color: transparent;border: none " class="like" onclick=pushLike(this)><i class="bi bi-emoji-heart-eyes-fill" style="font-size: 1.5rem;color: #ADB5BD"></i></button>
-                            </div>
+                        <button style="background-color: transparent;border: none " class="like" onclick=pushLike(this)>
+                            <i class="bi bi-emoji-heart-eyes-fill" style="font-size: 1.5rem;color: #ADB5BD"></i>
+                        </button>
+                    </div>
                     <div class="no2">
-                                <button  style="background-color: transparent;border: none " class="hate" onclick=deleteLike(this)><i class="bi bi-emoji-heart-eyes-fill" style="font-size: 1.5rem; color: #EC6090"></i>
-                                </button>
-                            </div>
+                        <button style="background-color: transparent;border: none " class="hate"
+                                onclick=deleteLike(this)><i class="bi bi-emoji-heart-eyes-fill"
+                                                            style="font-size: 1.5rem; color: #EC6090"></i>
+                        </button>
+                    </div>
                 </div>
                 <div style="margin-top: -8px; margin-bottom: -15px" class="d-flex justify-content-center">
-                <p style="font-size: 12px; color: white" class="NumberOfLike"></p>
+                    <p style="font-size: 12px; color: white" class="NumberOfLike"></p>
                 </div>
 
 
@@ -275,14 +282,14 @@
             <!--modal footer start-->
 
             <div id="updateDelete" class="modal-footer border-0" style="background-color: #1F2122;">
-<!--                <div class="updateDelete">-->
-                            <form class="deleteFeed" method="post">
-                                <button type="submit">삭제</button>
-                            </form>
-                            <form class="updateFeed" method="get">
-                                <button>수정</button>
-                            </form>
-<!--                </div>-->
+                <!--                <div class="updateDelete">-->
+                <form class="deleteFeed" method="post">
+                    <button type="submit">삭제</button>
+                </form>
+                <form class="updateFeed" method="get">
+                    <button>수정</button>
+                </form>
+                <!--                </div>-->
             </div>
 
             <!--modal footer end-->

--- a/src/main/resources/templates/feed/write.html
+++ b/src/main/resources/templates/feed/write.html
@@ -34,6 +34,23 @@
     <script src="/js/popup.js"></script>
     <script src="/js/custom.js"></script>
 
+    <style>
+        .input-file-button{
+            padding: 6px 25px;
+            background-color:#E75E8D;
+            border-radius: 8px;
+            color: white;
+            cursor: pointer;
+        }
+
+        input[type=file]::file-selector-button {
+            padding: 6px 25px;
+            background-color:#E75E8D;
+            border-radius: 8px;
+            color: white;
+            cursor: pointer;
+        }
+    </style>
 </head>
 <body>
 <div id="js-preloader" class="js-preloader">
@@ -97,7 +114,7 @@
     <div class="row">
         <div class="col-lg-12">
             <div class="page-content">
-                <form action="/feed" method="post">
+                <form action="/feed" method="post" enctype="multipart/form-data">
 
                     <div class="mb-3 row">
                         <label for="writer" style="color: #d3d6d8" class="col-sm-2 col-form-label fw-semibold">작성자</label>
@@ -115,15 +132,26 @@
                         </div>
                     </div>
 
-                    <input th:value="${member.getId()}" name="memberId" hidden="hidden"><br>
-                    <input th:value="${cocktailId}" name="cocktailId" hidden="hidden"><br>
 
                     <div class="mb-3 row">
-                        <label for="inputContent" class="col-sm-2 col-form-label text-white fw-semibold">내용</label>
+                        <label for="photo" style="color: #d3d6d8" class="form-label col-sm-2 col-form-label fw-semibold">사진</label>
+                        <div class="col-sm-10">
+                            <input type="file" style="color: #d3d6d8;background-color: transparent; " class="form-control-sm" id="photo"
+                                    name="photo">
+                        </div>
+                    </div>
+
+                    <input th:value="${member.getId()}" name="memberId" hidden="hidden"><br>
+                    <input th:value="${cocktailId}" name="cocktailId" hidden="hidden"><br>
+                    <input type="hidden" value="FEED" name="category">
+
+                    <div class="mb-3 row">
+                        <label for="inputContent" style="color: #d3d6d8;" class="col-sm-2 col-form-label fw-semibold">내용</label>
                         <div class="col-sm-10">
                             <textarea style="background-color: transparent ;color: #d3d6d8" class="form-control fw-semibold" id="inputContent" name="content"></textarea>
                         </div>
                     </div>
+
                     <button style="margin-top: 30px; margin-bottom: -20px" type="submit" class="customBtn">
                     <div class="main-border-button">
                         <a type="submit" class="customLink" >작성</a>


### PR DESCRIPTION

# 무슨 이유로 코드를 변경했는지

---
* #188 
* #191 
* #192 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 사진을 업로드하고 업로드한 사진을 조회할 수 있는 기능을 추가했습니다.
* 추가로 사진을 업로드 하지 않은 피드는 default사진을 일단 보이도록 설정했습니다.
---

# 관련 스크린샷

---
* 
![image](https://github.com/chain-smoker/Marronnier/assets/74136791/2b7c708c-f078-4924-bc13-4c91e4c17a9c)
![image](https://github.com/chain-smoker/Marronnier/assets/74136791/5f9d1e74-8699-48d0-b1ff-8c0eccd52f52)

---

# 테스트 계획 또는 완료 사항

---
* 시간이 없어서 테스트는 일단 나중에 진행하겠습니다.
